### PR TITLE
If no image icon in settingsflyout is provided, make sure it doesn't take up space

### DIFF
--- a/src/Callisto/themes/Generic.xaml
+++ b/src/Callisto/themes/Generic.xaml
@@ -440,7 +440,7 @@ limitations under the License.-->
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="30" />
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
 
                                     <Button x:Name="SettingsBackButton" Margin="0,3,0,0" Grid.Column="0" Style="{StaticResource SettingsBackButtonStyle}" HorizontalAlignment="Left" />


### PR DESCRIPTION
if no image icon in settingsflyout is provided, make sure it doesn't take up space but leave the room for the HeaderText
