### PR TITLE
Open SettingsPane on close configurable

### DIFF
--- a/src/Callisto/Controls/Settings/SettingsFlyout.cs
+++ b/src/Callisto/Controls/Settings/SettingsFlyout.cs
@@ -90,7 +90,10 @@ namespace Callisto.Controls
             {
                 _hostPopup.IsOpen = false;
             }
-            SettingsPane.Show();
+            if (this.ShowSettingsPaneOnClose)
+            {
+                SettingsPane.Show();
+            }
         }
         
         void OnHostPopupClosed(object sender, object e)
@@ -130,6 +133,15 @@ namespace Callisto.Controls
                         f._hostPopup.IsOpen = (bool)args.NewValue;
                     }
                 }));
+
+        public bool ShowSettingsPaneOnClose
+        {
+            get { return (bool)GetValue(ShowSettingsPaneOnCloseProperty); }
+            set { SetValue(ShowSettingsPaneOnCloseProperty, value); }
+        }
+
+        public static readonly DependencyProperty ShowSettingsPaneOnCloseProperty =
+            DependencyProperty.Register("ShowSettingsPaneOnClose", typeof(bool), typeof(SettingsFlyout), new PropertyMetadata(true));
 
         public SolidColorBrush HeaderBrush
         {

--- a/src/Callisto/themes/Generic.xaml
+++ b/src/Callisto/themes/Generic.xaml
@@ -437,11 +437,12 @@ limitations under the License.-->
         <Setter Property="Background" Value="{StaticResource ApplicationPageBackgroundThemeBrush}" />
         <Setter Property="HeaderBrush" Value="{StaticResource SettingsFlyoutHeaderBackgroundBrush}" />
         <Setter Property="HeaderText" Value="{StaticResource SettingsFlyoutHeaderTextDefault}" />
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
         <Setter Property="MaxWidth" Value="646" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingsFlyout">
-                    <Border BorderBrush="{TemplateBinding HeaderBrush}" BorderThickness="0,0,0,0" VerticalAlignment="Stretch">
+                    <Border BorderBrush="{TemplateBinding HeaderBrush}" BorderThickness="{TemplateBinding BorderThickness}" VerticalAlignment="Stretch">
                         <Grid Background="{TemplateBinding Background}" VerticalAlignment="Stretch" >
                             <!-- Root grid definition -->
                             <Grid.RowDefinitions>

--- a/src/Callisto/themes/Generic.xaml
+++ b/src/Callisto/themes/Generic.xaml
@@ -441,7 +441,7 @@ limitations under the License.-->
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingsFlyout">
-                    <Border BorderBrush="{TemplateBinding HeaderBrush}" BorderThickness="1,0,0,0" VerticalAlignment="Stretch">
+                    <Border BorderBrush="{TemplateBinding HeaderBrush}" BorderThickness="0,0,0,0" VerticalAlignment="Stretch">
                         <Grid Background="{TemplateBinding Background}" VerticalAlignment="Stretch" >
                             <!-- Root grid definition -->
                             <Grid.RowDefinitions>


### PR DESCRIPTION
Make the opening of the SettingsPane configurable, so you can opt-out. 
This is useful in cases where you want to invoke the dialog from another place then the SettingsPane.
I also made the border configurable based on the BorderThickness property. This makes sense and also adds flexibility. 

By default nothing changes with respect to the current code.
