### PR TITLE
Flyout repositioning on Child.SizeChanged

### DIFF
--- a/src/Callisto.TestApp/SamplePages/FlyoutSample.xaml.cs
+++ b/src/Callisto.TestApp/SamplePages/FlyoutSample.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -114,8 +114,9 @@ namespace Callisto.TestApp.SamplePages
 			Flyout f = new Flyout();
 
 			Border b = new Border();
-			b.Width = 300;
-			b.Height = 125;
+			//b.Width = 300;
+			//b.Height = 125;
+			var sp = new StackPanel();
 
 			TextBlock tb = new TextBlock();
             tb.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Center;
@@ -123,8 +124,11 @@ namespace Callisto.TestApp.SamplePages
             tb.TextWrapping = TextWrapping.Wrap;
 			tb.FontSize = 24.667;
 			tb.Text = "This is a basic ContentControl so put anything you want in here.";
-
-			b.Child = tb;
+			sp.Children.Add(tb);
+			Button btn = new Button() { Content = new TextBlock() { Text = "Resize" } };
+			btn.Click += (s, a) => btn.Height = btn.ActualHeight + 20;
+			sp.Children.Add(btn);
+			b.Child = sp;
 
 			f.Content = b;
 

--- a/src/Callisto/Controls/Flyout/Flyout.cs
+++ b/src/Callisto/Controls/Flyout/Flyout.cs
@@ -94,25 +94,21 @@ namespace Callisto.Controls
         }
 
         #region Methods and Events
-        private void OnHostPopupOpened(object sender, object e)
-        {
-            // there seems to be some issue where the mesaure is happening too fast when the size
-            // of the flyout is 0,0.  This attempts to solve this. 
-            // credit to avidgator/jvlppm for suggestions on github project
-            if (_hostPopup.ActualHeight == 0 || _hostPopup.ActualWidth == 0)
-            {
-                SizeChangedEventHandler updatePosition = null;
-                updatePosition = (s, eP) =>
-                    {
-                        if (eP.NewSize.Width != 0 && eP.NewSize.Height != 0)
-                        {
-                            OnHostPopupOpened(s, eP);
-                            SizeChanged -= updatePosition;
-                        }
-                    };
-                SizeChanged += updatePosition;
-            }
 
+
+	protected override Size MeasureOverride(Size availableSize)
+	{
+		if (Content is UIElement)
+		{
+			(Content as UIElement).Measure(availableSize);
+			return (Content as UIElement).DesiredSize;
+		}
+		else
+			return base.MeasureOverride(availableSize);
+	}
+
+        private void OnHostPopupOpened(object sender, object e)
+        {  
             _hostPopup.HorizontalOffset = this.HorizontalOffset;
             _hostPopup.VerticalOffset = this.VerticalOffset;
 


### PR DESCRIPTION
Not sure if it's safe to delete the code I just deleted, but it seems to be a sizing hack that MeasureOverride should handle now. Also without removing it there's a potential for a layout cycle.
