### PR TITLE
Settings Management

### DIFF
--- a/src/Callisto/Callisto.csproj
+++ b/src/Callisto/Callisto.csproj
@@ -150,6 +150,12 @@
     <Compile Include="Extensions\WebViewExtension.cs" />
     <Compile Include="OAuth\OAuthHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SettingsManagement\AppSettings.cs" />
+    <Compile Include="SettingsManagement\INotifySettingChanged.cs" />
+    <Compile Include="SettingsManagement\ISettingsCommandInfo.cs" />
+    <Compile Include="SettingsManagement\SettingChangedEventArgs.cs" />
+    <Compile Include="SettingsManagement\SettingsCommandInfo.cs" />
+    <Compile Include="SettingsManagement\SettingsUserControl.cs" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="LocalizedStrings\en-US\Resources.resw">

--- a/src/Callisto/Callisto.csproj
+++ b/src/Callisto/Callisto.csproj
@@ -155,7 +155,6 @@
     <Compile Include="SettingsManagement\ISettingsCommandInfo.cs" />
     <Compile Include="SettingsManagement\SettingChangedEventArgs.cs" />
     <Compile Include="SettingsManagement\SettingsCommandInfo.cs" />
-    <Compile Include="SettingsManagement\SettingsUserControl.cs" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="LocalizedStrings\en-US\Resources.resw">

--- a/src/Callisto/Callisto.sln
+++ b/src/Callisto/Callisto.sln
@@ -1,65 +1,65 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 11
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Callisto", "Callisto.csproj", "{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Callisto.TestApp", "..\Callisto.TestApp\Callisto.TestApp.csproj", "{9EF330B5-90B7-4946-B775-0F44000049E3}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BuildInfo", "BuildInfo", "{3F7842E1-DCE8-4989-A8F6-3EB77138B4CF}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\SDKManifest.xml = ..\..\SDKManifest.xml
 		..\..\build.bat = ..\..\build.bat
 		..\..\buildvsix.bat = ..\..\buildvsix.bat
 		..\..\nuget\Callisto\Callisto.nuspec = ..\..\nuget\Callisto\Callisto.nuspec
 		..\..\readme.md = ..\..\readme.md
+		..\..\SDKManifest.xml = ..\..\SDKManifest.xml
 	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM = Debug|ARM
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM = Release|ARM
 		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|ARM.ActiveCfg = Debug|ARM
-		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|ARM.Build.0 = Debug|ARM
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|ARM.ActiveCfg = Debug|ARM
+		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|ARM.Build.0 = Debug|ARM
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|x64.ActiveCfg = Debug|x64
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|x64.Build.0 = Debug|x64
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|x86.ActiveCfg = Debug|x86
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Debug|x86.Build.0 = Debug|x86
-		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|ARM.ActiveCfg = Release|ARM
-		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|ARM.Build.0 = Release|ARM
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|ARM.ActiveCfg = Release|ARM
+		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|ARM.Build.0 = Release|ARM
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|x64.ActiveCfg = Release|x64
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|x64.Build.0 = Release|x64
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|x86.ActiveCfg = Release|x86
 		{42E8BE6B-9A3C-4236-A0C7-8A8DBD757021}.Release|x86.Build.0 = Release|x86
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.ActiveCfg = Debug|ARM
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.Build.0 = Debug|ARM
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.Deploy.0 = Debug|ARM
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.ActiveCfg = Debug|ARM
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.Build.0 = Debug|ARM
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|ARM.Deploy.0 = Debug|ARM
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x64.ActiveCfg = Debug|x64
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x64.Build.0 = Debug|x64
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x64.Deploy.0 = Debug|x64
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x86.ActiveCfg = Debug|x86
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x86.Build.0 = Debug|x86
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Debug|x86.Deploy.0 = Debug|x86
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.ActiveCfg = Release|ARM
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.Build.0 = Release|ARM
-		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.Deploy.0 = Release|ARM
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.ActiveCfg = Release|ARM
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.Build.0 = Release|ARM
+		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|ARM.Deploy.0 = Release|ARM
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|x64.ActiveCfg = Release|x64
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|x64.Build.0 = Release|x64
 		{9EF330B5-90B7-4946-B775-0F44000049E3}.Release|x64.Deploy.0 = Release|x64

--- a/src/Callisto/SettingsManagement/AppSettings.cs
+++ b/src/Callisto/SettingsManagement/AppSettings.cs
@@ -1,0 +1,185 @@
+﻿using Callisto.Controls;
+using Callisto.Controls.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Windows.Storage;
+using Windows.UI.ApplicationSettings;
+using Windows.UI.Popups;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Callisto.SettingsManagement
+{
+    /// <summary>
+    /// Provides methods and properties allowing a Windows Store app to easily
+    /// implement the settings contract.
+    /// </summary>
+    public sealed partial class AppSettings : INotifySettingChanged
+    {        
+        #region events
+        
+        /// <summary>
+        /// Occurs when a setting value changes.
+        /// </summary>
+        public event EventHandler<SettingChangedEventArgs> SettingChanged;
+
+        #endregion
+        
+        #region fields
+        private readonly Dictionary<object, ISettingsCommandInfo> commands = new Dictionary<object, ISettingsCommandInfo>();
+        private SolidColorBrush headerBrush;
+        private static volatile AppSettings instance;
+        private SettingsFlyout settingsFlyout;
+        private BitmapImage smallLogoImageSource;
+        private static object syncRoot = new object();
+        private VisualElement visualElement;     
+        #endregion
+        
+        #region constructors
+        
+        private AppSettings()
+        {
+            Configure();
+        }
+
+        #endregion
+        
+        #region properties
+        
+        #region ContentBackgroundBrush
+        
+        /// <summary>
+        /// Gets or sets the background brush for the content area of the settings flyout.
+        /// </summary>
+        /// <value>The <see cref="SolidColorBrush"/> for the background of the content area of the settings flyout.</value>
+        [Obsolete("This is provided for backwards compatability until a proper light theme can be created so settings content will display corectly on a white background.", false)]
+        public SolidColorBrush ContentBackgroundBrush { get; set; }
+        
+        #endregion
+        
+        #region Current
+        
+        /// <summary>
+        /// Provides access to the app settings contract.
+        /// </summary>
+        /// <value>The app settings contract.</value>
+        public static AppSettings Current
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    lock (syncRoot)
+                    {
+                        if (instance == null)
+                        {
+                            instance = new AppSettings();
+                        }
+                    }
+                }
+
+                return instance;
+            }
+        }
+            
+        #endregion
+
+        #region VisualElements
+        /// <summary>
+        /// Gets a <see cref="VisualElement"/> instance which contains specific
+        /// information from the application manifest.
+        /// </summary>
+        public VisualElement VisualElements
+        {
+            get
+            {
+                return this.visualElement;
+            }
+        }
+        #endregion
+
+        #endregion
+
+        #region methods
+
+        #region AddCommand
+        /// <summary>
+        /// Add a <see cref="UserControl"/> to the settings contract using the specified header.
+        /// </summary>
+        /// <typeparam name="T">A <see cref="UserControl"/> which represents the content for the settings flyout.</typeparam>
+        /// <param name="headerText">The header to be displayed in the Settings charm.</param>
+        /// <param name="width">(Optional) The width of the settings flyout. The default is <see cref="SettingsFlyout.SettingsFlyoutWidth.Narrow">SettingsFlyout.SettingsFlyoutWidth.Narrow</see></param>
+        public void AddCommand<T>(string headerText, SettingsFlyout.SettingsFlyoutWidth width = SettingsFlyout.SettingsFlyoutWidth.Narrow) where T : UserControl, new()
+        {
+            string key = headerText.Trim().Replace(" ", "");
+
+            if (!commands.ContainsKey(key))
+            {
+                this.commands.Add(key, new SettingsCommandInfo<T>(headerText, width));
+            }
+        }
+        #endregion
+
+        #region CommandsRequested
+        private void CommandsRequested(SettingsPane sender, SettingsPaneCommandsRequestedEventArgs args)
+        {
+            foreach (var item in this.commands)
+            {
+                var command = new SettingsCommand(item.Key, item.Value.HeaderText, SettingsCommandInvokedHandler);
+                args.Request.ApplicationCommands.Add(command);
+            }
+        }
+        #endregion
+
+        #region Configure
+        private async void Configure()
+        {
+            visualElement = await AppManifestHelper.GetManifestVisualElementsAsync();
+            headerBrush = new SolidColorBrush(visualElement.BackgroundColor);
+            smallLogoImageSource = new BitmapImage(visualElement.SmallLogoUri);
+            SettingsPane.GetForCurrentView().CommandsRequested += AppSettings.Current.CommandsRequested;
+        }
+        #endregion
+
+        #region SettingsCommandInvokedHandler
+        private void SettingsCommandInvokedHandler(IUICommand command)
+        {
+            ISettingsCommandInfo commandInfo = commands[command.Id];
+
+            settingsFlyout = new SettingsFlyout();
+            settingsFlyout.HeaderBrush = this.headerBrush;
+            settingsFlyout.SmallLogoImageSource = this.smallLogoImageSource;
+            settingsFlyout.HeaderText = command.Label;
+            if (this.ContentBackgroundBrush != null)
+            {
+                settingsFlyout.ContentBackgroundBrush = this.ContentBackgroundBrush;    
+            }
+
+            settingsFlyout.Content = commandInfo.Instance;
+            settingsFlyout.FlyoutWidth = commandInfo.Width;
+            settingsFlyout.IsOpen = true;
+        }
+        #endregion
+
+        #region SignalSettingChanged
+        /// <summary>
+        /// Raises the <see cref="INotifySettingChanged.SettingChanged"/> event.
+        /// </summary>
+        /// <param name="settingName">(Optional) The name of the setting which changed.</param>
+        public void SignalSettingChanged([CallerMemberName] string settingName = "")
+        {
+            var handler = this.SettingChanged;
+            if (handler != null)
+            {
+                var e = new SettingChangedEventArgs(settingName);
+                handler(this, e);
+            }
+        }
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/Callisto/SettingsManagement/INotifySettingChanged.cs
+++ b/src/Callisto/SettingsManagement/INotifySettingChanged.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Callisto.SettingsManagement
+{
+    /// <summary>
+    /// Notifies clients that a setting value has changed.
+    /// </summary>
+    public interface INotifySettingChanged
+    {
+        #region events
+        /// <summary>
+        /// Occurs when a setting value changes.
+        /// </summary>
+        event EventHandler<SettingChangedEventArgs> SettingChanged;
+        #endregion
+
+        #region properties
+        #endregion
+
+        #region methods
+        #endregion
+    }
+
+}

--- a/src/Callisto/SettingsManagement/ISettingsCommandInfo.cs
+++ b/src/Callisto/SettingsManagement/ISettingsCommandInfo.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Callisto.Controls;
+
+namespace Callisto.SettingsManagement
+{
+    /// <summary>
+    /// Represents the information for a <see cref="SettingsCommandInfo"/>.
+    /// </summary>
+    interface ISettingsCommandInfo
+    {
+        #region events
+        #endregion
+
+        #region properties
+
+        #region HeaderText
+        /// <summary>
+        /// Gets the header of the settings command to display in the Settings charm.
+        /// </summary>
+        /// <value>The header of the settings command.</value>
+        string HeaderText
+        {
+            get;
+        }
+        #endregion
+
+        #region Instance
+        /// <summary>
+        /// Gets the instantiated <see cref="UserControl"/> instance which represents
+        /// the content of the settings flyout.
+        /// </summary>
+        UserControl Instance
+        {
+            get;
+        }
+        #endregion
+
+        #region Width
+        /// <summary>
+        /// Gets the width of the settings flyout.
+        /// </summary>
+        /// <value>The width of the settings flyout.</value>
+        SettingsFlyout.SettingsFlyoutWidth Width
+        {
+            get;
+        }
+        #endregion
+
+        #endregion
+
+        #region methods
+        #endregion
+    }
+}

--- a/src/Callisto/SettingsManagement/SettingChangedEventArgs.cs
+++ b/src/Callisto/SettingsManagement/SettingChangedEventArgs.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+
+namespace Callisto.SettingsManagement
+{
+    /// <summary>
+    /// Provides data for the <see cref="INotifySettingChanged.SettingChanged"/>
+    /// event.</summary>
+    public sealed class SettingChangedEventArgs : System.EventArgs
+    {
+        #region events
+        #endregion
+
+        #region fields
+        private readonly string settingName;
+        #endregion
+
+        #region constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.ComponentModel.SettingChangedEventArgs"/>
+        /// class.</summary>
+        /// <param name="settingName">The name of the setting that changed.</param>
+        public SettingChangedEventArgs(string settingName)
+        {
+            this.settingName = settingName;
+        }
+        #endregion
+
+        #region properties
+
+        #region SettingName
+        /// <summary>
+        /// Gets the name of the setting that changed.
+        /// </summary>
+        /// <returns>The name of the setting that changed.</returns>
+        public string SettingName
+        {
+            get
+            {
+                return this.settingName;
+            }
+        }
+        #endregion
+
+        #endregion
+
+        #region methods
+        #endregion
+    }
+}

--- a/src/Callisto/SettingsManagement/SettingsCommandInfo.cs
+++ b/src/Callisto/SettingsManagement/SettingsCommandInfo.cs
@@ -1,0 +1,75 @@
+﻿using Callisto.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Callisto.SettingsManagement
+{
+    /// <summary>
+    /// Represents the information for a <see cref="SettingsCommandInfo"/>.
+    /// </summary>
+    /// <typeparam name="T">A <see cref="UserControl"/> which represents the content for the settings flyout.</typeparam>
+    class SettingsCommandInfo<T> : ISettingsCommandInfo where T : UserControl, new()
+    {
+        #region events
+        #endregion
+
+        #region fields
+        #endregion
+
+        #region constructors
+        public SettingsCommandInfo(string headerText, SettingsFlyout.SettingsFlyoutWidth width)
+        {
+            this.HeaderText = headerText;
+            this.Width = width;
+        }
+        #endregion
+
+        #region properties
+
+        #region HeaderText
+        /// <summary>
+        /// Gets the header of the settings command to display in the Settings charm.
+        /// </summary>
+        /// <value>The header of the settings command.</value>
+        public string HeaderText
+        {
+            get;
+            private set;
+        }
+        #endregion
+
+        #region Instance
+        /// <summary>
+        /// Gets the instantiated <see cref="UserControl"/> instance which represents
+        /// the content of the settings flyout.
+        /// </summary>
+        public UserControl Instance
+        {
+            get
+            {
+                return new T();
+            }
+        }
+        #endregion
+
+        #region Width
+        /// <summary>
+        /// Gets the width of the settings flyout.
+        /// </summary>
+        /// <value>The width of the settings flyout.</value>
+        public SettingsFlyout.SettingsFlyoutWidth Width
+        {
+            get;
+            private set;
+        }
+        #endregion
+        #endregion
+
+        #region methods
+        #endregion
+    }
+}

--- a/src/Callisto/SettingsManagement/SettingsUserControl.cs
+++ b/src/Callisto/SettingsManagement/SettingsUserControl.cs
@@ -1,0 +1,39 @@
+﻿using Callisto.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Callisto.SettingsManagement
+{
+    public class SettingsUserControl : UserControl
+    {
+        public SettingsFlyout.SettingsFlyoutWidth SettingsWidth
+        {
+            get
+            {
+                return (SettingsFlyout.SettingsFlyoutWidth)GetValue(SettingsWidthProperty);
+            }
+            set
+            {
+                SetValue(SettingsWidthProperty, value);
+            }
+        }
+
+        public static readonly DependencyProperty SettingsWidthProperty =
+            DependencyProperty.Register("SettingsWidth", typeof(SettingsFlyout.SettingsFlyoutWidth), typeof(SettingsUserControl),
+                                        new PropertyMetadata(SettingsFlyout.SettingsFlyoutWidth.Narrow, OnSettingsWidthPropertyChanged));
+
+        private static void OnSettingsWidthPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            SettingsUserControl s = d as SettingsUserControl;
+            if (s != null)
+            {
+                s.Width = (double)e.NewValue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provided a simpler way to add settings to an app. To add settings, you can now use:

AppSettings.Current.AddCommand<GeneralSettingsControl>("Options");
AppSettings.Current.AddCommand<AboutView>("About", SettingsFlyout.SettingsFlyoutWidth.Wide);

The AppSettings class is effectively a singleton wrapper that manages creating and configuring the SettingsFlyout appropriately and also handles the CommandsRequested event. This means the developer only has to worry about creating the UserControl which represents the actual content of the SettingsFlyout and adding it to their app by just a single line of code (as shown above).
