### PR TITLE
update of LiveTile Control to allow the usage ot DataTemplateSelector

### DIFF
--- a/src/Callisto.TestApp/Callisto.TestApp.csproj
+++ b/src/Callisto.TestApp/Callisto.TestApp.csproj
@@ -172,6 +172,7 @@
     <Compile Include="StartPage.xaml.cs">
       <DependentUpon>StartPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TemplateSelectors\LiveTileTemplateSelector.cs" />
     <Compile Include="VisualTreeAdapter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Callisto.TestApp/SamplePages/LiveTileSample.xaml
+++ b/src/Callisto.TestApp/SamplePages/LiveTileSample.xaml
@@ -3,20 +3,47 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Callisto.TestApp.SamplePages"
+     xmlns:TS="using:Callisto.TestApp.TemplateSelectors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
      xmlns:callisto="using:Callisto.Controls"
 	mc:Ignorable="d">
 
-	<Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
+    <Page.Resources>
+        <DataTemplate x:Key="FrontTemplate">
+            <Image Stretch="UniformToFill" >
+                <Image.Source>
+                    <BitmapImage UriSource="{Binding ImageUri}" />
+                </Image.Source>
+            </Image>
+        </DataTemplate>
+
+        <DataTemplate x:Key="BackTemplate">
+            <Grid Margin="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock FontWeight="Bold" Text="{Binding Title}" />
+                <TextBlock Text="{Binding Text}" Grid.Row="1"/>
+            </Grid>
+        </DataTemplate>
+
+        <TS:LiveTileTemplateSelector x:Key="LiveTileTemplateSelector" Front="{StaticResource FrontTemplate}" Back="{StaticResource BackTemplate}" />
+    </Page.Resources>
+
+    <Grid Background="{StaticResource ApplicationPageBackgroundThemeBrush}">
 
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="245" />
 			<ColumnDefinition Width="155" />
+            <ColumnDefinition Width="155" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="155" />
 			<RowDefinition Height="155" />
+            <RowDefinition Height="155" />
 			<RowDefinition Height="155" />
 		</Grid.RowDefinitions>
 
@@ -96,5 +123,10 @@
 				</DataTemplate>
 			</callisto:LiveTile.ItemTemplate>
 		</callisto:LiveTile>
-	</Grid>
+
+        <callisto:LiveTile x:Name="liveTile4"
+                    ItemTemplateSelector="{StaticResource LiveTileTemplateSelector}"
+					Grid.Column="3" Grid.Row="6" Margin="5">
+        </callisto:LiveTile>
+    </Grid>
 </Page>

--- a/src/Callisto.TestApp/SamplePages/LiveTileSample.xaml.cs
+++ b/src/Callisto.TestApp/SamplePages/LiveTileSample.xaml.cs
@@ -29,6 +29,12 @@ namespace Callisto.TestApp.SamplePages
 			public Uri ReadMoreUri { get; set; }
 		}
 
+        public class LiveTileData2
+        {
+            public string Title { get; set; }
+            public string Text { get; set; }
+        }
+
 		public LiveTileSample()
 		{
 			this.InitializeComponent();
@@ -57,7 +63,28 @@ namespace Callisto.TestApp.SamplePages
                 ReadMoreUri = new Uri("http://en.wikipedia.org/wiki/Grasshopper")
             });
 			DataContext = tileData;
-		}
+            this.LoadContentForSelector();
+        }
+
+        private void LoadContentForSelector()
+        {
+            List<object> list = new List<object>();
+            list.Add(new LiveTileData()
+            {
+                Name = "Butterfly",
+                Description = "A butterfly is a mainly day-flying insect of the order Lepidoptera, which includes the butterflies and moths. Like other holometabolous insects, the butterfly's life cycle consists of four parts: egg, larva, pupa and adult.",
+                ImageUri = new Uri("ms-appx:/Images/butterfly.jpg"),
+                ReadMoreUri = new Uri("http://en.wikipedia.org/wiki/Butterfly")
+            });
+            list.Add(new LiveTileData2()
+            {
+                Title = "My Title",
+                Text = "Here my little description"
+            });
+
+            this.liveTile4.ItemsSource = list;
+        }
+
 		private async void OnReadMoreLink_Click(object sender, RoutedEventArgs e)
 		{
 			var link = (sender as FrameworkElement).Tag as Uri;

--- a/src/Callisto.TestApp/TemplateSelectors/LiveTileTemplateSelector.cs
+++ b/src/Callisto.TestApp/TemplateSelectors/LiveTileTemplateSelector.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Callisto.TestApp.TemplateSelectors
+{
+    public class LiveTileTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate Front { get; set; }
+        public DataTemplate Back { get; set; }
+
+        protected override Windows.UI.Xaml.DataTemplate SelectTemplateCore(object item, Windows.UI.Xaml.DependencyObject container)
+        {
+            if (item is Callisto.TestApp.SamplePages.LiveTileSample.LiveTileData)
+                return this.Front;
+            else
+                return this.Back;
+
+            return base.SelectTemplateCore(item, container);
+        }
+    }
+}

--- a/src/Callisto/Controls/LiveTile/LiveTile.cs
+++ b/src/Callisto/Controls/LiveTile/LiveTile.cs
@@ -202,9 +202,9 @@ namespace Callisto.Controls
 					_translate.X = _translate.Y = 0;
 				}
 				if(_currentElement != null)
-					_currentElement.DataContext = GetCurrent();
+                    SetDataContext(_currentElement, GetCurrent());
 				if(_nextElement != null)
-					_nextElement.DataContext = GetNext();
+                    SetDataContext(_nextElement, GetNext());
 			};
 			sb.Begin();
 		}
@@ -250,9 +250,9 @@ namespace Callisto.Controls
 		{
 			_currentIndex = 0;
 			if (_currentElement != null)
-				_currentElement.DataContext = GetCurrent();
+                SetDataContext(_currentElement, GetCurrent());
 			if (_nextElement != null)
-				_nextElement.DataContext = GetNext();
+                SetDataContext(_nextElement, GetNext());
 			if (_timer == null)
 			{
 				_timer = new DispatcherTimer() { Interval = TimeSpan.FromSeconds(1) };
@@ -261,6 +261,15 @@ namespace Callisto.Controls
 			}
 			_timer.Start();
 		}
+
+        private void SetDataContext(FrameworkElement element, object dataContext)
+        {
+            element.DataContext = dataContext;
+            if (ItemTemplateSelector != null)
+            {
+                (element as ContentPresenter).ContentTemplate = ItemTemplateSelector.SelectTemplate(element.DataContext, element);
+            }
+        }
 
 		#endregion
 
@@ -307,6 +316,21 @@ namespace Callisto.Controls
 		/// </summary>
 		public static readonly DependencyProperty ItemTemplateProperty =
 			DependencyProperty.Register("ItemTemplate", typeof(DataTemplate), typeof(LiveTile), null);
+
+        /// <summary>
+        /// Identifies the <see cref="ItemTemplateSelector"/> property.
+        /// </summary>
+        public static readonly DependencyProperty ItemTemplateSelectorProperty =
+            DependencyProperty.Register("ItemTemplateSelector", typeof(DataTemplateSelector), typeof(LiveTile), null);
+
+        /// <summary>
+        /// Gets or sets the item template selector
+        /// </summary>
+        public DataTemplateSelector ItemTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(ItemTemplateSelectorProperty); }
+            set { SetValue(ItemTemplateSelectorProperty, value); }
+        }
 
 		/// <summary>
 		/// Gets or sets the direction the tile slides in.

--- a/src/Callisto/themes/Generic.xaml
+++ b/src/Callisto/themes/Generic.xaml
@@ -636,11 +636,11 @@ limitations under the License.-->
                                 <ContentPresenter x:Name="Current"
                                                       DataContext="{x:Null}"
                                                       Content="{Binding}" 
-                                                      ContentTemplate="{TemplateBinding ItemTemplate}" />
+                                                      ContentTemplate="{TemplateBinding ItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
                                 <ContentPresenter  x:Name="Next" 
                                                       DataContext="{x:Null}"
                                                       Content="{Binding}" 
-                                                      ContentTemplate="{TemplateBinding ItemTemplate}" />
+                                                      ContentTemplate="{TemplateBinding ItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
                             </StackPanel>
                         </Canvas>
                         <Border

--- a/src/Callisto/themes/Generic.xaml
+++ b/src/Callisto/themes/Generic.xaml
@@ -636,11 +636,11 @@ limitations under the License.-->
                                 <ContentPresenter x:Name="Current"
                                                       DataContext="{x:Null}"
                                                       Content="{Binding}" 
-                                                      ContentTemplate="{TemplateBinding ItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
+                                                      ContentTemplate="{TemplateBinding ItemTemplate}" />
                                 <ContentPresenter  x:Name="Next" 
                                                       DataContext="{x:Null}"
                                                       Content="{Binding}" 
-                                                      ContentTemplate="{TemplateBinding ItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
+                                                      ContentTemplate="{TemplateBinding ItemTemplate}" />
                             </StackPanel>
                         </Canvas>
                         <Border


### PR DESCRIPTION
update of LiveTile Control to allow the usage of DataTemplateSelector, not the perfect integration but it's working and useful.

With the current datacontext logic, Its not possible to apply a DataContentSelector. To fix that, I call manually the DataTemplateSelector after each switch on the current and next item.

It's working and allows the creation of many different ContentTemplate in a easy way.

The fix answers the issue #221
