### PR TITLE
CustomDialog checks for an existing binding of IsOpen before setting it; fixes #244

### DIFF
--- a/src/Callisto/Controls/CustomDialog/CustomDialog.cs
+++ b/src/Callisto/Controls/CustomDialog/CustomDialog.cs
@@ -47,7 +47,7 @@ namespace Callisto.Controls
                         {
                             BackButtonClicked(bbs, bba);
                         }
-                        else
+                        else if(GetBindingExpression(IsOpenProperty) == null)
                         {
                             IsOpen = false;
                         }


### PR DESCRIPTION
This is a possible fix/workaround for the problem described at #244, which causes an MVVM usage of CustomDialog to break. The binding for IsOpen is overridden when the Back button is handled using the Command parameter instead of the click handler.

Note: This will break previously working code, if a binding was used to just open the dialog.
