### PR TITLE
Remove build warnings

### DIFF
--- a/src/Callisto/Callisto.csproj
+++ b/src/Callisto/Callisto.csproj
@@ -251,7 +251,7 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="XamlTypeInfoBuildTask.targets" Condition="Exists('XamlTypeInfoBuildTask.targets')" />  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Callisto/Controls/LiveTile/LiveTile.cs
+++ b/src/Callisto/Controls/LiveTile/LiveTile.cs
@@ -81,7 +81,7 @@ namespace Callisto.Controls
 		
 		/// <summary>
 		/// Invoked whenever application code or internal processes (such as a rebuilding
-		/// layout pass) call <see cref="ApplyTemplate"/>. In simplest terms, this means the method
+		/// layout pass) call <see cref="OnApplyTemplate"/>. In simplest terms, this means the method
 		/// is called just before a UI element displays in an application. Override this
 		/// method to influence the default post-template logic of a class.
 		/// </summary>

--- a/src/Callisto/Effects/TiltEffect.cs
+++ b/src/Callisto/Effects/TiltEffect.cs
@@ -299,23 +299,24 @@ namespace Callisto.Effects
 		}
 
 		/// <summary>
-		/// Begins the tilt effect by preparing the control and doing the 
+		/// Begins the tilt effect by preparing the control and doing the
 		/// initial animation.
 		/// </summary>
 		/// <param name="element">The element to tilt.</param>
 		/// <param name="touchPoint">The touch point, in element coordinates.</param>
 		/// <param name="centerPoint">The center point of the element in element
 		/// coordinates.</param>
-		/// <param name="centerDelta">The delta between the 
-		/// <paramref name="element"/>'s center and the container's center.</param>
-		private static void BeginTiltEffect(FrameworkElement element, Point touchPoint, Point centerPoint, Point centerDelta, Pointer p)
+		/// <param name="centerDelta">The delta between the
+		/// <param name="pointer">The pointer causing the tilt effect.</param>
+		/// <paramref name="element" />'s center and the container's center.</param>
+		private static void BeginTiltEffect(FrameworkElement element, Point touchPoint, Point centerPoint, Point centerDelta, Pointer pointer)
 		{
 			if (tiltReturnStoryboard != null)
 			{
 				StopTiltReturnStoryboardAndCleanup();
 			}
 
-			if (PrepareControlForTilt(element, centerDelta, p) == false)
+			if (PrepareControlForTilt(element, centerDelta, pointer) == false)
 			{
 				return;
 			}
@@ -334,12 +335,13 @@ namespace Callisto.Effects
 		/// <param name="element">The control that is to be tilted.</param>
 		/// <param name="centerDelta">Delta between the element's center and the
 		/// tilt container's.</param>
+		/// <param name="pointer">The pointer causing the tilt effect.</param>
 		/// <returns>true if successful; false otherwise.</returns>
 		/// <remarks>
 		/// This method is conservative; it will fail any attempt to tilt a 
 		/// control that already has a projection on it.
 		/// </remarks>
-		private static bool PrepareControlForTilt(FrameworkElement element, Point centerDelta, Pointer p)
+		private static bool PrepareControlForTilt(FrameworkElement element, Point centerDelta, Pointer pointer)
 		{
 			// Prevents interference with any existing transforms
 			if (element.Projection != null || (element.RenderTransform != null && element.RenderTransform.GetType() != typeof(MatrixTransform)))
@@ -363,7 +365,7 @@ namespace Callisto.Effects
 			element.PointerMoved += TiltEffect_PointerMoved;
 			element.PointerReleased += TiltEffect_PointerReleased;
 			element.PointerCaptureLost += TiltEffect_PointerCaptureLost;
-			element.CapturePointer(p);
+			element.CapturePointer(pointer);
 			return true;
 		}
 

--- a/src/Callisto/XamlTypeInfoBuildTask.targets
+++ b/src/Callisto/XamlTypeInfoBuildTask.targets
@@ -1,0 +1,48 @@
+﻿<!--
+// This task disable doc warnings in the auto-generated XamlTypeInfo.g.cs file,
+// and also hides the public class from intellisense.
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<UsingTask TaskName="XamlTypeInfoBuildTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <InputFilename ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System.Core" />
+            <Using Namespace="System" />
+            <Using Namespace="Microsoft.Build.Framework" />
+            <Using Namespace="Microsoft.Build.Utilities" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                try {
+                    if (!System.IO.File.Exists(InputFilename)) 
+						return false; 
+					string code = System.IO.File.ReadAllText(InputFilename);
+
+					if (code.StartsWith("#pragma warning disable 1591,0618")) //Already modified 
+						return true; 
+					int idx = code.IndexOf("[System.CodeDom.Compiler.GeneratedCodeAttribute"); 
+					if (idx < 0) 
+						return false; 
+					string insert = "[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]\n    "; 
+					code = "#pragma warning disable 1591,0618\n" + code.Substring(0, idx) + insert + code.Substring(idx) + 
+						"#pragma warning restore 1591\n"; 
+					System.IO.File.WriteAllText(InputFilename, code); 
+					return true; 
+                }
+                catch (Exception ex) {
+                    Log.LogErrorFromException(ex);
+                    return false;
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+	<Target Name="XamlTypeInfoBuildTask"
+					AfterTargets="MarkupCompilePass2"
+					BeforeTargets="CoreCompile">
+		<XamlTypeInfoBuildTask InputFilename="$(IntermediateOutputPath)\XamlTypeInfo.g.cs" />
+	</Target>
+</Project>


### PR DESCRIPTION
- Removes build warnings generated by XamlTypeInfo.g.cs.
- Resolves a couple of xml doc warnings in LiveTile and TiltEffect
- Hides public classes in XamlTypeInfo from intellisense.
