### PR TITLE
Reduce build warnings

### DIFF
--- a/src/Callisto/Controls/Common/AppManifestHelper.cs
+++ b/src/Callisto/Controls/Common/AppManifestHelper.cs
@@ -22,6 +22,9 @@ using System.Xml.Linq;
 
 namespace Callisto.Controls.Common
 {
+	/// <summary>
+	/// A helper API that retrieves some data from your app's AppxManifest.xml file for you.
+	/// </summary>
     public class AppManifestHelper
     {
         public async static Task<VisualElement> GetManifestVisualElementsAsync()
@@ -56,11 +59,29 @@ namespace Callisto.Controls.Common
 
     public class VisualElement
     {
+		/// <summary>
+		/// Gets or sets the display name.
+		/// </summary>
         public string DisplayName { get; set; }
+		/// <summary>
+		/// Gets or sets the description.
+		/// </summary>
         public string Description { get; set; }
+		/// <summary>
+		/// Gets or sets the logo URI.
+		/// </summary>
         public Uri LogoUri { get; set; }
+		/// <summary>
+		/// Gets or sets the small logo URI.
+		/// </summary>
         public Uri SmallLogoUri { get; set; }
+		/// <summary>
+		/// Gets or sets the background color as string.
+		/// </summary>
         public string BackgroundColorAsString { get; set; }
+		/// <summary>
+		/// Gets the color of the background.
+		/// </summary>
         public Windows.UI.Color BackgroundColor
         {
             get

--- a/src/Callisto/Controls/Common/ExpandDirection.cs
+++ b/src/Callisto/Controls/Common/ExpandDirection.cs
@@ -25,11 +25,27 @@ using System;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// Expand Direction used by the <see cref="Primitives.LinearClipper" />
+	/// </summary>
+	/// <seealso cref="Primitives.LinearClipper.ExpandDirection"/>
     public enum ExpandDirection
     {
+		/// <summary>
+		/// Down
+		/// </summary>
         Down = 0,
+		/// <summary>
+		/// Up
+		/// </summary>
         Up = 1,
+		/// <summary>
+		/// The left
+		/// </summary>
         Left = 2,
+		/// <summary>
+		/// The right
+		/// </summary>
         Right = 3,
     }
 }

--- a/src/Callisto/Controls/CustomDialog/CustomDialog.cs
+++ b/src/Callisto/Controls/CustomDialog/CustomDialog.cs
@@ -20,17 +20,39 @@ using Windows.UI.Xaml.Controls;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// CustomDialog is a control intended to be used full-screen and to mimic the MessageDialog behavior.
+	/// Currently in WinRT, the MessageDialog is limited to text/button content only. If that is your
+	/// scenario, you should absolutely use that API. CustomDialog exists to serve the more advanced
+	/// scenario of needing richer content in your UI modal dialog
+	/// This is a "UI modal" dialog meaning that it is intended to block UI interaction until the dialog 
+	/// is dismissed. It does not create true modal behavior, so actions in the background could still
+	/// be executing.
+	/// </summary>
+	/// <remarks>
+	/// CustomDialog is a ContentControl. The properties on the control itself that you want to be aware of are
+	/// <see cref="Title"/> (required), <see cref="Control.Background"/>, and <see cref="BackButtonVisibility  "/>
+	/// to set to your desired behavior.
+	/// </remarks>
     [TemplatePart(Name = CustomDialog.PART_BACK_BUTTON, Type = typeof(Button))]
     [TemplatePart(Name = CustomDialog.PART_ROOT_BORDER, Type = typeof(Border))]
     [TemplatePart(Name = CustomDialog.PART_ROOT_GRID, Type = typeof(Grid))]
     [TemplatePart(Name = CustomDialog.PART_CONTENT, Type = typeof(ContentPresenter))]
     public class CustomDialog : ContentControl
     {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CustomDialog"/> class.
+		/// </summary>
         public CustomDialog()
         {
             DefaultStyleKey = typeof(CustomDialog);
         }
 
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass) 
+		/// call ApplyTemplate. In simplest terms, this means the method is called just before a UI
+		/// element displays in your app. Override this method to influence the default post-template logic of a class.
+		/// </summary>
         protected override void OnApplyTemplate()
         {
             _rootGrid = (Grid)GetTemplateChild(PART_ROOT_GRID);
@@ -83,6 +105,9 @@ namespace Callisto.Controls
         }
 
         #region Events
+		/// <summary>
+		/// Occurs when the back button was clicked.
+		/// </summary>
         public event RoutedEventHandler BackButtonClicked;
         #endregion
 
@@ -100,22 +125,38 @@ namespace Callisto.Controls
         #endregion
 
         #region Dependency Properties
-        public Visibility BackButtonVisibility
+
+		/// <summary>
+		/// Gets or sets the back button visibility.
+		/// </summary>
+		public Visibility BackButtonVisibility
         {
             get { return (Visibility)GetValue(BackButtonVisibilityProperty); }
             set { SetValue(BackButtonVisibilityProperty, value); }
         }
 
-        public static readonly DependencyProperty BackButtonVisibilityProperty =
+		/// <summary>
+		/// Identifies the <see cref="BackButtonVisibility"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty BackButtonVisibilityProperty =
             DependencyProperty.Register("BackButtonVisibility", typeof(Visibility), typeof(CustomDialog), new PropertyMetadata(Visibility.Collapsed));
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the dialog is open.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this dialog is open; otherwise, <c>false</c>.
+		/// </value>
         public bool IsOpen
         {
             get { return (bool)GetValue(IsOpenProperty); }
             set { SetValue(IsOpenProperty, value); }
         }
 
-        public static readonly DependencyProperty IsOpenProperty =
+		/// <summary>
+		/// Identifies the <see cref="IsOpen"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty IsOpenProperty =
             DependencyProperty.Register("IsOpen", typeof(bool), typeof(CustomDialog), new PropertyMetadata(false, OnIsOpenPropertyChanged));
 
         private static void OnIsOpenPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -130,31 +171,49 @@ namespace Callisto.Controls
             }
         }
 
-        public string Title
+		/// <summary>
+		/// Gets or sets the title.
+		/// </summary>
+		public string Title
         {
             get { return (string)GetValue(TitleProperty); }
             set { SetValue(TitleProperty, value); }
         }
 
-        public static readonly DependencyProperty TitleProperty =
+		/// <summary>
+		/// Identifies the <see cref="Title"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty TitleProperty =
             DependencyProperty.Register("Title", typeof(string), typeof(CustomDialog), null);
 
+		/// <summary>
+		/// Gets or sets the back button command.
+		/// </summary>
         public ICommand BackButtonCommand
         {
             get { return (ICommand)GetValue(BackButtonCommandProperty); }
             set { SetValue(BackButtonCommandProperty, value); }
         }
 
-        public static readonly DependencyProperty BackButtonCommandProperty =
+		/// <summary>
+		/// Identifies the <see cref="BackButtonCommand"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty BackButtonCommandProperty =
             DependencyProperty.Register("BackButtonCommand", typeof(ICommand), typeof(CustomDialog), new PropertyMetadata(DependencyProperty.UnsetValue));
 
-        public object BackButtonCommandParameter
+		/// <summary>
+		/// Gets or sets the back button command parameter.
+		/// </summary>
+		public object BackButtonCommandParameter
         {
             get { return (object)GetValue(BackButtonCommandParameterProperty); }
             set { SetValue(BackButtonCommandParameterProperty, value); }
         }
 
-        public static readonly DependencyProperty BackButtonCommandParameterProperty =
+		/// <summary>
+		/// Identifies the <see cref="BackButtonCommandParameter"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty BackButtonCommandParameterProperty =
             DependencyProperty.Register("BackButtonCommandParameter", typeof(object), typeof(CustomDialog), new PropertyMetadata(DependencyProperty.UnsetValue));
         #endregion
     }

--- a/src/Callisto/Controls/DropDownButton/DropDownButton.cs
+++ b/src/Callisto/Controls/DropDownButton/DropDownButton.cs
@@ -18,6 +18,9 @@ using Windows.UI.Xaml.Controls;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// Drop-down Button control
+	/// </summary>
     public sealed class DropDownButton : Button
     {
         private TextBlock _arrowGlyph;
@@ -29,17 +32,37 @@ namespace Callisto.Controls
         private const string ARROW_GLYPH_MEDIUM = "\uE099"; // >= 16pt; < 33pt
         private const string ARROW_GLYPH_LARGE  = "\uE228"; // > 33pt;
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DropDownButton"/> class.
+		/// </summary>
         public DropDownButton()
         {
             DefaultStyleKey = typeof(DropDownButton);
         }
 
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call
+		/// ApplyTemplate. In simplest terms, this means the method is called just before a UI element
+		/// displays in your app. Override this method to influence the default post-template logic of a class.
+		/// </summary>
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
             _arrowGlyph = GetTemplateChild(PART_ARROW_GLYPH) as TextBlock;
         }
 
+		/// <summary>
+		/// Provides the behavior for the Measure pass of the layout cycle. Classes can override this
+		/// method to define their own Measure pass behavior.
+		/// </summary>
+		/// <param name="availableSize">The available size that this object can give to child objects. 
+		/// Infinity can be specified as a value to indicate that the object will size to whatever content
+		/// is available.</param>
+		/// <returns>
+		/// The size that this object determines it needs during layout, based on its calculations of
+		/// the allocated sizes for child objects or based on other considerations such as a fixed 
+		/// container size.
+		/// </returns>
         protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
         {
             EvaluateArrowGlyph();

--- a/src/Callisto/Controls/DynamicTextBlock/DynamicTextBlock.cs
+++ b/src/Callisto/Controls/DynamicTextBlock/DynamicTextBlock.cs
@@ -61,7 +61,11 @@ namespace Callisto.Controls
             get { return (string)GetValue(TextProperty); }
             set { SetValue(TextProperty, value); }
         }
-        public static readonly DependencyProperty TextProperty =
+
+		/// <summary>
+		/// Identifies the <see cref="Text"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty TextProperty =
             DependencyProperty.Register("Text", typeof(string), typeof(DynamicTextBlock),
             new PropertyMetadata(string.Empty, new PropertyChangedCallback(OnTextChanged)));
 
@@ -70,6 +74,10 @@ namespace Callisto.Controls
             ((DynamicTextBlock)d).OnTextChanged(e);
         }
 
+		/// <summary>
+		/// Raises the <see cref="E:TextChanged" /> event.
+		/// </summary>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
         protected virtual void OnTextChanged(DependencyPropertyChangedEventArgs e)
         {
             this.InvalidateMeasure();
@@ -87,7 +95,10 @@ namespace Callisto.Controls
             get { return (TextWrapping)GetValue(TextWrappingProperty); }
             set { SetValue(TextWrappingProperty, value); }
         }
-        public static readonly DependencyProperty TextWrappingProperty =
+		/// <summary>
+		/// Identifies the <see cref="TextWrapping"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty TextWrappingProperty =
             DependencyProperty.Register("TextWrapping", typeof(TextWrapping), typeof(DynamicTextBlock),
             new PropertyMetadata(TextWrapping.NoWrap, new PropertyChangedCallback(OnTextWrappingChanged)));
 
@@ -96,6 +107,11 @@ namespace Callisto.Controls
             ((DynamicTextBlock)d).OnTextWrappingChanged(e);
         }
 
+		/// <summary>
+		/// Called when the <see cref="E:TextWrappingChanged" /> event occurs.
+		/// </summary>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> 
+		/// instance containing the event data.</param>
         protected virtual void OnTextWrappingChanged(DependencyPropertyChangedEventArgs e)
         {
             this.textBlock.TextWrapping = (TextWrapping)e.NewValue;
@@ -115,7 +131,10 @@ namespace Callisto.Controls
             set { SetValue(LineHeightProperty, value); }
         }
 
-        public static readonly DependencyProperty LineHeightProperty =
+		/// <summary>
+		/// Identifies the <see cref="LineHeight"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty LineHeightProperty =
             DependencyProperty.Register("LineHeight", typeof(double), typeof(DynamicTextBlock),
             new PropertyMetadata(0.0, new PropertyChangedCallback(OnLineHeightChanged)));
 
@@ -124,6 +143,10 @@ namespace Callisto.Controls
             ((DynamicTextBlock)d).OnLineHeightChanged(e);
         }
 
+		/// <summary>
+		/// Called when the <see cref="E:LineHeightChanged" /> event occurs.
+		/// </summary>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
         protected virtual void OnLineHeightChanged(DependencyPropertyChangedEventArgs e)
         {
             textBlock.LineHeight = LineHeight;
@@ -142,7 +165,11 @@ namespace Callisto.Controls
             get { return (LineStackingStrategy)GetValue(LineStackingStrategyProperty); }
             set { SetValue(LineStackingStrategyProperty, value); }
         }
-        public static readonly DependencyProperty LineStackingStrategyProperty =
+
+		/// <summary>
+		/// Identifies the <see cref="LineStackingStrategy"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty LineStackingStrategyProperty =
             DependencyProperty.Register("LineStackingStrategy", typeof(LineStackingStrategy), typeof(DynamicTextBlock),
             new PropertyMetadata(LineStackingStrategy.BlockLineHeight, new PropertyChangedCallback(OnLineStackingStrategyChanged)));
 
@@ -151,6 +178,10 @@ namespace Callisto.Controls
             ((DynamicTextBlock)d).OnLineStackingStrategyChanged(e);
         }
 
+		/// <summary>
+		/// Called when the <see cref="E:LineStackingStrategyChanged" /> event occurs.
+		/// </summary>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
         protected virtual void OnLineStackingStrategyChanged(DependencyPropertyChangedEventArgs e)
         {
             this.textBlock.LineStackingStrategy = (LineStackingStrategy)e.NewValue;

--- a/src/Callisto/Controls/FlipViewIndicator/FlipViewIndicator.cs
+++ b/src/Callisto/Controls/FlipViewIndicator/FlipViewIndicator.cs
@@ -26,20 +26,41 @@ using Windows.UI.Xaml.Media;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// FlipViewIndicator is a companion control to be used exclusively with a FlipView control. It serves
+	/// the purpose of providing some hinting UI to the user where they are in the navigation of items
+	/// within a FlipView. This is similar UI as seen in the Windows Store application when viewing the 
+	/// screenshots.
+	/// </summary>
+	/// <remarks>
+	/// The best usage is to be immediately underneath a FlipView and this is easily accomplished by using 
+	/// a <see cref="StackPanel"/> as demonstrated below in Usage. When done this way the margins of the 
+	/// FlipViewIndicator are set correctly. If using in other means, you may need to adjust margins on
+	/// the indicator.
+	/// </remarks>
     public sealed class FlipViewIndicator : ListBox
     {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FlipViewIndicator"/> class.
+		/// </summary>
         public FlipViewIndicator()
         {
             this.DefaultStyleKey = typeof(FlipViewIndicator);
         }
 
+		/// <summary>
+		/// Gets or sets the flip view.
+		/// </summary>
         public FlipView FlipView
         {
             get { return (FlipView)GetValue(FlipViewProperty); }
             set { SetValue(FlipViewProperty, value); }
         }
 
-        public static readonly DependencyProperty FlipViewProperty =
+		/// <summary>
+		/// Identifies the <see cref="FlipView"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty FlipViewProperty =
             DependencyProperty.Register("FlipView", typeof(FlipView), typeof(FlipViewIndicator), new PropertyMetadata(null, (depobj, args) =>
                 {
                     FlipViewIndicator fvi = (FlipViewIndicator)depobj;

--- a/src/Callisto/Controls/Flyout/Flyout.cs
+++ b/src/Callisto/Controls/Flyout/Flyout.cs
@@ -58,7 +58,11 @@ namespace Callisto.Controls
 
         #region Public Properties
         // public accessor for the inner Popup
-        public Popup HostPopup
+		
+		/// <summary>
+		/// Gets the inner popup.
+		/// </summary>
+		public Popup HostPopup
         {
             get { return _hostPopup; }
         }
@@ -543,26 +547,45 @@ namespace Callisto.Controls
             ((Flyout)sender).IsHitTestVisible = true;
         }
 
+		/// <summary>
+		/// Occurs when the flyout was closed.
+		/// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly", Justification = "Runtime EventHandler")]
         public event EventHandler<object> Closed;
         #endregion Methods and Events
 
         #region Dependency Properties
-        public Thickness HostMargin
+
+		/// <summary>
+		/// Gets or sets the host margin.
+		/// </summary>
+		public Thickness HostMargin
         {
             get { return (Thickness)GetValue(HostMarginProperty); }
             set { SetValue(HostMarginProperty, value); }
         }
 
-        public static readonly DependencyProperty HostMarginProperty =
+		/// <summary>
+		/// Identifies the <see cref="HostMargin"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty HostMarginProperty =
             DependencyProperty.Register("HostMargin", typeof(Thickness), typeof(Flyout), new PropertyMetadata(0));
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the flyout is open.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this flyout is open; otherwise, <c>false</c>.
+		/// </value>
         public bool IsOpen
         {
             get { return (bool)GetValue(IsOpenProperty); }
             set { SetValue(IsOpenProperty, value); }
         }
-        public static readonly DependencyProperty IsOpenProperty =
+		/// <summary>
+		/// Identifies the <see cref="IsOpen"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty IsOpenProperty =
             DependencyProperty.Register("IsOpen", typeof(bool), typeof(Flyout), new PropertyMetadata(false, (obj, args) =>
             {
                 if (args.NewValue != args.OldValue)
@@ -572,43 +595,70 @@ namespace Callisto.Controls
                 }
             }));
 
-        public UIElement PlacementTarget
+		/// <summary>
+		/// Gets or sets the placement target.
+		/// </summary>
+		public UIElement PlacementTarget
         {
             get { return (UIElement)GetValue(PlacementTargetProperty); }
             set { SetValue(PlacementTargetProperty, value); }
         }
 
-        public static readonly DependencyProperty PlacementTargetProperty =
+		/// <summary>
+		/// Identifies the <see cref="PlacementTarget"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty PlacementTargetProperty =
             DependencyProperty.Register("PlacementTarget", typeof(UIElement), typeof(Flyout), null);
 
-        public Windows.UI.Xaml.Controls.Primitives.PlacementMode Placement
+		/// <summary>
+		/// Gets or sets the placement.
+		/// </summary>
+		public Windows.UI.Xaml.Controls.Primitives.PlacementMode Placement
         {
             get { return (Windows.UI.Xaml.Controls.Primitives.PlacementMode)GetValue(PlacementProperty); }
             set { SetValue(PlacementProperty, value); }
         }
 
-        public static readonly DependencyProperty PlacementProperty =
+		/// <summary>
+		/// Identifies the <see cref="Placement"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty PlacementProperty =
             DependencyProperty.Register("Placement", typeof(Windows.UI.Xaml.Controls.Primitives.PlacementMode), typeof(Flyout), null);
 
-        public double HorizontalOffset
+		/// <summary>
+		/// Gets or sets the horizontal offset.
+		/// </summary>
+		public double HorizontalOffset
         {
             get { return (double)GetValue(HorizontalOffsetProperty); }
             set { SetValue(HorizontalOffsetProperty, value); }
         }
 
-        public static readonly DependencyProperty HorizontalOffsetProperty =
+		/// <summary>
+		/// Identifies the <see cref="HorizontalOffset"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty HorizontalOffsetProperty =
             DependencyProperty.Register("HorizontalOffset", typeof(double), typeof(Flyout), new PropertyMetadata(0.0));
 
-        public double VerticalOffset
+		/// <summary>
+		/// Gets or sets the vertical offset.
+		/// </summary>
+		public double VerticalOffset
         {
             get { return (double)GetValue(VerticalOffsetProperty); }
             set { SetValue(VerticalOffsetProperty, value); }
         }
 
-        public static readonly DependencyProperty VerticalOffsetProperty =
+		/// <summary>
+		/// Identifies the <see cref="VerticalOffset"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty VerticalOffsetProperty =
             DependencyProperty.Register("VerticalOffset", typeof(double), typeof(Flyout), new PropertyMetadata(0.0));
         #endregion Dependency Properties
 
+		/// <summary>
+		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+		/// </summary>
         public void Dispose()
         {
             if (this._hostPopup != null)

--- a/src/Callisto/Controls/Menu/Menu.cs
+++ b/src/Callisto/Controls/Menu/Menu.cs
@@ -23,14 +23,25 @@ using Windows.UI.Xaml.Markup;
 
 namespace Callisto.Controls
 {
-    [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyout.")]
+	/// <summary>
+	/// OBSOLETE. Menu is a special type of Flyout which serves the purpose for Menu commands.
+	/// Most of the time this will be from an AppBar or a header area. The intent is text 
+	/// commands only and not meant always to be styled.
+	/// </summary>
+	/// <remarks>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.MenuFlyout"/> controls in Windows 8.1.
+	/// </remarks>
+	[Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyout.")]
     [ContentProperty(Name="Items")]
     public sealed class Menu : Control
     {
         private ObservableCollection<MenuItemBase> _items;
         private ItemsControl _itemContainerList;
 
-        public ObservableCollection<MenuItemBase> Items
+		/// <summary>
+		/// Gets the menu items.
+		/// </summary>
+		public ObservableCollection<MenuItemBase> Items
         {
             get { return _items; }
         }
@@ -137,6 +148,9 @@ namespace Callisto.Controls
             return index;
         }
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Menu"/> class.
+		/// </summary>
         public Menu()
         {
             this.DefaultStyleKey = typeof(Menu);
@@ -155,6 +169,12 @@ namespace Callisto.Controls
             ((Menu)sender).IsHitTestVisible = true;
         }
 
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass) 
+		/// call ApplyTemplate. In simplest terms, this means the method is called just before a UI 
+		/// element displays in your app. Override this method to influence the default post-template
+		/// logic of a class.
+		/// </summary>
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();

--- a/src/Callisto/Controls/Menu/MenuItem.cs
+++ b/src/Callisto/Controls/Menu/MenuItem.cs
@@ -22,16 +22,31 @@ using Windows.UI.Xaml.Input;
 
 namespace Callisto.Controls
 {
-    [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyoutItem.")]
+	/// <summary>
+	/// OBSOLETE. An item for a menu, including separators and contains the command point for the menu item
+	/// </summary>
+	/// <remarks>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.MenuFlyout"/> controls in Windows 8.1.
+	/// </remarks>
+	[Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyoutItem.")]
     [TemplateVisualState(Name = MenuItem.StateBase, GroupName = MenuItem.GroupCommon)]
     [TemplateVisualState(Name = MenuItem.StateHover, GroupName = MenuItem.GroupCommon)]
     [TemplateVisualState(Name = MenuItem.StatePressed, GroupName = MenuItem.GroupCommon)]
     [TemplateVisualState(Name = MenuItem.StateDisabled, GroupName = MenuItem.GroupCommon)]
     public class MenuItem : MenuItemBase
     {
-        public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(MenuItem), null);
-        public static readonly DependencyProperty CommandProperty = DependencyProperty.Register("Command", typeof(ICommand), typeof(MenuItem), null);
-        public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register("CommandParameter", typeof(object), typeof(MenuItem), null);
+		/// <summary>
+		/// Identifies the <see cref="Text"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(MenuItem), null);
+		/// <summary>
+		/// Identifies the <see cref="Command"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty CommandProperty = DependencyProperty.Register("Command", typeof(ICommand), typeof(MenuItem), null);
+		/// <summary>
+		/// Identifies the <see cref="CommandParameter"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register("CommandParameter", typeof(object), typeof(MenuItem), null);
 
         private const string GroupCommon = "Common";
         private const string StateBase = "Base";
@@ -41,6 +56,9 @@ namespace Callisto.Controls
 
         private bool _isActive;
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MenuItem"/> class.
+		/// </summary>
         public MenuItem()
             : base()
         {
@@ -48,6 +66,10 @@ namespace Callisto.Controls
             _isActive = false;
         }
 
+		/// <summary>
+		/// Called before the PointerEntered event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnPointerEntered(Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             _isActive = true;
@@ -56,6 +78,10 @@ namespace Callisto.Controls
             Focus(Windows.UI.Xaml.FocusState.Programmatic);
         }
 
+		/// <summary>
+		/// Called before the PointerExited event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnPointerExited(Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             base.OnPointerExited(e);
@@ -63,6 +89,10 @@ namespace Callisto.Controls
             UpdateState(true);
         }
 
+		/// <summary>
+		/// Called before the PointerMoved event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnPointerMoved(Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             _isActive = true;
@@ -71,6 +101,10 @@ namespace Callisto.Controls
             Focus(Windows.UI.Xaml.FocusState.Programmatic);
         }
 
+		/// <summary>
+		/// Called before the GotFocus event occurs.
+		/// </summary>
+		/// <param name="e">The data for the event.</param>
         protected override void OnGotFocus(RoutedEventArgs e)
         {
             base.OnGotFocus(e);
@@ -78,6 +112,10 @@ namespace Callisto.Controls
             UpdateState(true);
         }
 
+		/// <summary>
+		/// Called before the LostFocus event occurs.
+		/// </summary>
+		/// <param name="e">The data for the event.</param>
         protected override void OnLostFocus(RoutedEventArgs e)
         {
             base.OnLostFocus(e);
@@ -85,6 +123,10 @@ namespace Callisto.Controls
             UpdateState(true);
         }
 
+		/// <summary>
+		/// Called before the KeyDown event occurs.
+		/// </summary>
+		/// <param name="e">The data for the event.</param>
         protected override void OnKeyDown(Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             base.OnKeyDown(e);
@@ -95,18 +137,30 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Called before the Tapped event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnTapped(TappedRoutedEventArgs e)
         {
             base.OnTapped(e);
             VisualStateManager.GoToState(this, StateBase, true);
         }
 
+		/// <summary>
+		/// Called before the PointerReleased event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnPointerReleased(Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             base.OnPointerReleased(e);
             VisualStateManager.GoToState(this, StateBase, true);
         }
 
+		/// <summary>
+		/// Called before the PointerPressed event occurs.
+		/// </summary>
+		/// <param name="e">Event data for the event.</param>
         protected override void OnPointerPressed(Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             base.OnPointerPressed(e);
@@ -132,19 +186,28 @@ namespace Callisto.Controls
             }
         }
 
-        public string Text
+		/// <summary>
+		/// Gets or sets the text.
+		/// </summary>
+		public string Text
         {
             get { return (string)GetValue(TextProperty); }
             set { SetValue(TextProperty, value); }
         }
 
-        public ICommand Command
+		/// <summary>
+		/// Gets or sets the command.
+		/// </summary>
+		public ICommand Command
         {
             get { return (ICommand)GetValue(CommandProperty); }
             set { SetValue(CommandProperty, value); }
         }
 
-        public object CommandParameter
+		/// <summary>
+		/// Gets or sets the command parameter.
+		/// </summary>
+		public object CommandParameter
         {
             get { return GetValue(CommandParameterProperty); }
             set { SetValue(CommandParameterProperty, value); }

--- a/src/Callisto/Controls/Menu/MenuItemBase.cs
+++ b/src/Callisto/Controls/Menu/MenuItemBase.cs
@@ -20,17 +20,32 @@ using Windows.UI.Xaml.Controls;
 
 namespace Callisto.Controls
 {
-    [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyoutItem.")]
+	/// <summary>
+	/// OBSOLETE. Base class for the menu items
+	/// </summary>
+	/// <remarks>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.MenuFlyout"/> controls in Windows 8.1.
+	/// </remarks>
+	[Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuFlyoutItem.")]
     public abstract class MenuItemBase : Control
     {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MenuItemBase"/> class.
+		/// </summary>
         protected MenuItemBase() { }
 
-        public Thickness MenuTextMargin
+		/// <summary>
+		/// Gets or sets the menu text margin.
+		/// </summary>
+		public Thickness MenuTextMargin
         {
             get { return (Thickness)GetValue(MenuTextMarginProperty); }
             set { SetValue(MenuTextMarginProperty, value); }
         }
 
+		/// <summary>
+		/// Identifies the <see cref="MenuTextMargin"/> dependency property
+		/// </summary>
         public static readonly DependencyProperty MenuTextMarginProperty =
             DependencyProperty.Register("MenuTextMargin", typeof(Thickness), typeof(MenuItemBase), null);
 

--- a/src/Callisto/Controls/Menu/MenuItemSeparator.cs
+++ b/src/Callisto/Controls/Menu/MenuItemSeparator.cs
@@ -17,9 +17,20 @@
 using System;
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// OBSOLETE. A MenuItem separator
+	/// </summary>
+	/// <remarks>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.MenuFlyout"/> controls in Windows 8.1.
+	/// </remarks>
+	/// <seealso cref="MenuItem"/>
+	/// <seealso cref="Menu"/>
     [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as MenuItemSeparator.")]
     public sealed class MenuItemSeparator : MenuItemBase
     {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MenuItemSeparator"/> class.
+		/// </summary>
         public MenuItemSeparator()
         {
             DefaultStyleKey = typeof(MenuItemSeparator);

--- a/src/Callisto/Controls/Menu/ToggleMenuItem.cs
+++ b/src/Callisto/Controls/Menu/ToggleMenuItem.cs
@@ -19,21 +19,39 @@ using Windows.UI.Xaml;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// OBSOLETE. A menu item that can be toggled.
+	/// </summary>
+	/// <remarks>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.MenuFlyout"/> controls in Windows 8.1.
+	/// </remarks>
     [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as ToggleMenuFlyoutItem.")]
     public sealed class ToggleMenuItem : MenuItem
     {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ToggleMenuItem"/> class.
+		/// </summary>
         public ToggleMenuItem()
         {
             DefaultStyleKey = typeof(ToggleMenuItem);
         }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the menu item is checked.
+		/// </summary>
+		/// <value>
+		/// 	<c>true</c> if this instance is checked; otherwise, <c>false</c>.
+		/// </value>
         public bool IsChecked
         {
             get { return (bool)GetValue(IsCheckedProperty); }
             set { SetValue(IsCheckedProperty, value); }
         }
 
-        public static readonly DependencyProperty IsCheckedProperty =
+		/// <summary>
+		/// Identifies the <see cref="IsChecked"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty IsCheckedProperty =
             DependencyProperty.Register("IsChecked", typeof(bool), typeof(ToggleMenuItem), null);
     }
 }

--- a/src/Callisto/Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/Callisto/Controls/NumericUpDown/NumericUpDown.cs
@@ -24,6 +24,12 @@ using Windows.UI.Xaml.Controls.Primitives;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// NumericUpDown is a "spinner" control for numeric values. It is a text entry field 
+	/// that presents itself with a "+" and "-" symbol for incrementing/decrementing the value.
+	/// The developer can choose Minimum and Maximum values in addition to the incremental value and
+	/// decimal places. It is meant for numbers only and is not a general purpose spinner control.
+	/// </summary>
     public sealed class NumericUpDown : TextBox
     {
         private RepeatButton _incrementButton;
@@ -34,6 +40,12 @@ namespace Callisto.Controls
 
         private int _delay = 500;
 
+		/// <summary>
+		/// Gets or sets the delay.
+		/// </summary>
+		/// <value>
+		/// The delay.
+		/// </value>
         public int Delay
         {
             get { return _delay; }
@@ -47,6 +59,12 @@ namespace Callisto.Controls
 
         private int _interval = 100;
 
+		/// <summary>
+		/// Gets or sets the interval.
+		/// </summary>
+		/// <value>
+		/// The interval.
+		/// </value>
         public int Interval
         {
             get { return _interval; }
@@ -58,6 +76,9 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NumericUpDown"/> class.
+		/// </summary>
         public NumericUpDown()
         {
             this.DefaultStyleKey = typeof(NumericUpDown);
@@ -66,6 +87,10 @@ namespace Callisto.Controls
             TextChanged += OnTextChanged;
         }
 
+		/// <summary>
+		/// Called before the KeyDown event occurs.
+		/// </summary>
+		/// <param name="e">The data for the event.</param>
         protected override void OnKeyDown(Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             base.OnKeyDown(e);
@@ -155,6 +180,11 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call ApplyTemplate.
+		/// In simplest terms, this means the method is called just before a UI element displays in your app. Override
+		/// this method to influence the default post-template logic of a class.
+		/// </summary>
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
@@ -247,13 +277,19 @@ namespace Callisto.Controls
         }
 
         #region Minimum
-        public double Minimum
+		/// <summary>
+		/// Gets or sets the minimum.
+		/// </summary>
+		public double Minimum
         {
             get { return (double)GetValue(MinimumProperty); }
             set { SetValue(MinimumProperty, value); }
         }
 
-        public static readonly DependencyProperty MinimumProperty =
+		/// <summary>
+		/// Identifies the <see cref="Minimum"/> property
+		/// </summary>
+		public static readonly DependencyProperty MinimumProperty =
             DependencyProperty.Register("Minimum", typeof(double), typeof(NumericUpDown),
                                         new PropertyMetadata(0.0, OnMinimumPropertyChanged));
 
@@ -291,13 +327,20 @@ namespace Callisto.Controls
         #endregion
 
         #region Maximum
+
+		/// <summary>
+		/// Gets or sets the maximum.
+		/// </summary>
         public double Maximum
         {
             get { return (double)GetValue(MaximumProperty); }
             set { SetValue(MaximumProperty, value); }
         }
 
-        public static readonly DependencyProperty MaximumProperty =
+		/// <summary>
+		/// Identifies the <see cref="Maximum"/> property
+		/// </summary>
+		public static readonly DependencyProperty MaximumProperty =
             DependencyProperty.Register("Maximum", typeof(double), typeof(NumericUpDown), new PropertyMetadata(100.0, OnMaximumPropertyChanged));
 
         private static void OnMaximumPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -325,13 +368,20 @@ namespace Callisto.Controls
         #endregion
 
         #region Increment
-        public double Increment
+		
+		/// <summary>
+		/// Gets or sets the increment.
+		/// </summary>
+		public double Increment
         {
             get { return (double)GetValue(IncrementProperty); }
             set { SetValue(IncrementProperty, value); }
         }
 
-        public static readonly DependencyProperty IncrementProperty =
+		/// <summary>
+		/// Identifies the <see cref="Increment"/> property
+		/// </summary>
+		public static readonly DependencyProperty IncrementProperty =
             DependencyProperty.Register("Increment", typeof(double), typeof(NumericUpDown), new PropertyMetadata(1.0, OnIncrementPropertyChanged));
 
         private static void OnIncrementPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -360,13 +410,19 @@ namespace Callisto.Controls
         #endregion
 
         #region DecimalPlaces
-        public int DecimalPlaces
+		/// <summary>
+		/// Gets or sets the decimal places.
+		/// </summary>
+		public int DecimalPlaces
         {
             get { return (int)GetValue(DecimalPlacesProperty); }
             set { SetValue(DecimalPlacesProperty, value); }
         }
 
-        public static readonly DependencyProperty DecimalPlacesProperty =
+		/// <summary>
+		/// Identifies the <see cref="DecimalPlaces"/> property
+		/// </summary>
+		public static readonly DependencyProperty DecimalPlacesProperty =
             DependencyProperty.Register("DecimalPlaces", typeof (int), typeof (NumericUpDown), new PropertyMetadata(0, OnDecimalPlacesPropertyChanged));
 
         private static void OnDecimalPlacesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -406,13 +462,20 @@ namespace Callisto.Controls
 
 
         #region Value
-        public double Value
+		
+		/// <summary>
+		/// Gets or sets the value.
+		/// </summary>
+		public double Value
         {
             get { return (double)GetValue(ValueProperty); }
             set { SetValue(ValueProperty, value); }
         }
 
-        public static readonly DependencyProperty ValueProperty =
+		/// <summary>
+		/// Identifies the <see cref="Value"/> property
+		/// </summary>
+		public static readonly DependencyProperty ValueProperty =
             DependencyProperty.Register("Value", typeof(double), typeof(NumericUpDown), new PropertyMetadata(0.0, OnValuePropertyChanged));
 
         private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Callisto/Controls/Rating/Rating.cs
+++ b/src/Callisto/Controls/Rating/Rating.cs
@@ -243,10 +243,13 @@ namespace Callisto.Controls
             set { SetValue(ValueProperty, value); }
         }
 
+		/// <summary>
+		/// Gets the weighted value.
+		/// </summary>
         public double WeightedValue { get; private set; }
 
         /// <summary>
-        /// Identifies the Value dependency property.
+		/// Identifies the <see cref="Value"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ValueProperty =
             DependencyProperty.Register(
@@ -315,33 +318,51 @@ namespace Callisto.Controls
         #endregion public double Value
 
         #region PointerPressedFill
-        public SolidColorBrush PointerPressedFill
+		/// <summary>
+		/// Gets or sets the PointerPressed brush color
+		/// </summary>
+		public SolidColorBrush PointerPressedFill
         {
             get { return (SolidColorBrush)GetValue(PointerPressedFillProperty); }
             set { SetValue(PointerPressedFillProperty, value); }
         }
 
-        public static readonly DependencyProperty PointerPressedFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="PointerPressedFill"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty PointerPressedFillProperty =
             DependencyProperty.Register("PointerPressedFill", typeof(SolidColorBrush), typeof(Rating), null);
         #endregion PoitnerPressedFill
 
         #region PointerOverFill
+		/// <summary>
+		/// Gets or sets the PointerOver brush color
+		/// </summary>
         public SolidColorBrush PointerOverFill
         {
             get { return (SolidColorBrush)GetValue(PointerOverFillProperty); }
             set { SetValue(PointerOverFillProperty, value); }
         }
 
-        public static readonly DependencyProperty PointerOverFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="PointerOverFillProperty"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty PointerOverFillProperty =
             DependencyProperty.Register("PointerOverFill", typeof(SolidColorBrush), typeof(Rating), null);
         #endregion PointerOverFill
 
         #region ReadonlyFill
 
-        public static readonly DependencyProperty ReadOnlyFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="ReadOnlyFill"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty ReadOnlyFillProperty =
             DependencyProperty.Register("ReadOnlyFill", typeof(SolidColorBrush), typeof(Rating), null);
 
-        public SolidColorBrush ReadOnlyFill
+		/// <summary>
+		/// Gets or sets the ReadOnly brush color
+		/// </summary>
+		public SolidColorBrush ReadOnlyFill
         {
             get { return (SolidColorBrush)GetValue(ReadOnlyFillProperty); }
             set { SetValue(ReadOnlyFillProperty, value); }

--- a/src/Callisto/Controls/Rating/RatingItem.cs
+++ b/src/Callisto/Controls/Rating/RatingItem.cs
@@ -160,7 +160,10 @@ namespace Callisto.Controls
             set { SetValue(PointerOverFillProperty, value); }
         }
 
-        public static readonly DependencyProperty PointerOverFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="PointerOverFill"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty PointerOverFillProperty =
             DependencyProperty.Register("PointerOverFill", typeof(SolidColorBrush), typeof(RatingItem), null); 
         #endregion PointerOverFill
 
@@ -174,16 +177,25 @@ namespace Callisto.Controls
             set { SetValue(PointerPressedFillProperty, value); }
         }
 
-        public static readonly DependencyProperty PointerPressedFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="PointerPressedFill"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty PointerPressedFillProperty =
             DependencyProperty.Register("PointerPressedFill", typeof(SolidColorBrush), typeof(RatingItem), null);
         #endregion
 
         #region ReadonlyFill
 
-        public static readonly DependencyProperty ReadOnlyFillProperty =
+		/// <summary>
+		/// Identifies the <see cref="ReadOnlyFill"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty ReadOnlyFillProperty =
             DependencyProperty.Register("ReadOnlyFill", typeof (SolidColorBrush), typeof (RatingItem), null);
 
-        public SolidColorBrush ReadOnlyFill
+		/// <summary>
+		/// Gets or sets the ReadOnly brush color
+		/// </summary>
+		public SolidColorBrush ReadOnlyFill
         {
             get { return (SolidColorBrush) GetValue(ReadOnlyFillProperty); }
             set { SetValue(ReadOnlyFillProperty, value); }

--- a/src/Callisto/Controls/Rating/ValueChangedEventArgs.cs
+++ b/src/Callisto/Controls/Rating/ValueChangedEventArgs.cs
@@ -23,11 +23,26 @@ using Windows.UI.Xaml;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// Event args for a value changing event
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
     public class ValueChangedEventArgs<T> : EventArgs
     {
+		/// <summary>
+		/// Gets the old value.
+		/// </summary>
         public T OldValue { get; private set; }
+		/// <summary>
+		/// Gets the new value.
+		/// </summary>
         public T NewValue { get; private set; }
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedEventArgs{T}"/> class.
+		/// </summary>
+		/// <param name="oldValue">The old value.</param>
+		/// <param name="newValue">The new value.</param>
         public ValueChangedEventArgs(T oldValue, T newValue)
         {
             OldValue = oldValue;

--- a/src/Callisto/Controls/Rating/ValueChangedEventHandler.cs
+++ b/src/Callisto/Controls/Rating/ValueChangedEventHandler.cs
@@ -22,5 +22,11 @@ using System.Threading.Tasks;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// Value changed event delegate
+	/// </summary>
+	/// <typeparam name="T">Value type</typeparam>
+	/// <param name="sender">The sender.</param>
+	/// <param name="e">The <see cref="Callisto.Controls.ValueChangedEventArgs{T}"/> instance containing the event data.</param>
     public delegate void ValueChangedEventHandler<T>(object sender, ValueChangedEventArgs<T> e);
 }

--- a/src/Callisto/Controls/Settings/SettingsFlyout.cs
+++ b/src/Callisto/Controls/Settings/SettingsFlyout.cs
@@ -28,6 +28,21 @@ using Windows.UI.Xaml.Media.Animation;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// OBSOLETE. This control is a helper control to provide the Settings charm experience for custom settings within your app.
+	/// It follows the specific Windows UI guidelines for layout and entrance/exit/positioning animations. It is a
+	/// content control for your settings that are app-wide or contextual to your current view.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This control is deprecated in favor of using the <see cref="Windows.UI.Xaml.Controls.SettingsFlyout"/> control in Windows 8.1.
+	/// </para>
+	/// <para>
+	/// This control is a helper control to provide the Settings charm experience for custom settings within your app. 
+	/// It follows the specific Windows UI guidelines for layout and entrance/exit/positioning animations. It is a 
+	/// content control for your settings that are app-wide or contextual to your current view.
+	/// </para>
+	/// </remarks>
     [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as SettingsFlyout.")]
     public sealed class SettingsFlyout : ContentControl
     {
@@ -53,7 +68,13 @@ namespace Callisto.Controls
         #endregion
 
         #region Overrides
-        protected override void OnApplyTemplate()
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass) 
+		/// call ApplyTemplate. In simplest terms, this means the method is called just before a UI 
+		/// element displays in your app. Override this method to influence the default post-template
+		/// logic of a class.
+		/// </summary>
+		protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
 
@@ -92,6 +113,9 @@ namespace Callisto.Controls
         #endregion Overrides
 
         #region Constructor
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SettingsFlyout"/> class.
+		/// </summary>
         public SettingsFlyout()
         {
             this.DefaultStyleKey = typeof(SettingsFlyout);
@@ -176,6 +200,9 @@ namespace Callisto.Controls
             }            
         }
 
+		/// <summary>
+		/// Occurs when back button is clicked.
+		/// </summary>
         public event EventHandler<BackClickedEventArgs> BackClicked;
 
         private void InvokeOnBackClick(BackClickedEventArgs args)
@@ -233,17 +260,29 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Gets a reference the to popup.
+		/// </summary>
         public Popup HostPopup { get { return _hostPopup; } }
         #endregion Constructor
 
         #region Dependency Properties
+		/// <summary>
+		/// Gets or sets a value indicating whether the flyout is open.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if this instance is open; otherwise, <c>false</c>.
+		/// </value>
         public bool IsOpen
         {
             get { return (bool)GetValue(IsOpenProperty); }
             set { SetValue(IsOpenProperty, value); }
         }
 
-        public static readonly DependencyProperty IsOpenProperty =
+		/// <summary>
+		/// Identifies the <see cref="IsOpen"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty IsOpenProperty =
             DependencyProperty.Register("IsOpen", typeof(bool), typeof(SettingsFlyout), new PropertyMetadata(false, (obj, args) =>
                 {
                     if (args.NewValue != args.OldValue)
@@ -253,13 +292,19 @@ namespace Callisto.Controls
                     }
                 }));
 
+		/// <summary>
+		/// Gets or sets the header brush.
+		/// </summary>
         public SolidColorBrush HeaderBrush
         {
             get { return (SolidColorBrush)GetValue(HeaderBrushProperty); }
             set { SetValue(HeaderBrushProperty, value); }
         }
 
-        public static readonly DependencyProperty HeaderBrushProperty =
+		/// <summary>
+		/// Identifies the <see cref="HeaderBrush"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty HeaderBrushProperty =
             DependencyProperty.Register("HeaderBrush", typeof(SolidColorBrush), typeof(SettingsFlyout), new PropertyMetadata(null, OnHeaderBrushColorChanged));
 
         private static void OnHeaderBrushColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -277,74 +322,122 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Gets or sets the width of the flyout.
+		/// </summary>
         public SettingsFlyoutWidth FlyoutWidth
         {
             get { return (SettingsFlyoutWidth)GetValue(FlyoutWidthProperty); }
             set { SetValue(FlyoutWidthProperty, value); }
         }
 
-        public static readonly DependencyProperty FlyoutWidthProperty =
+		/// <summary>
+		/// Identifies the <see cref="FlyoutWidth"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty FlyoutWidthProperty =
             DependencyProperty.Register("FlyoutWidth", typeof(SettingsFlyoutWidth), typeof(SettingsFlyout), new PropertyMetadata(SettingsFlyoutWidth.Narrow));
 
 
+		/// <summary>
+		/// Gets or sets the header text.
+		/// </summary>
         public string HeaderText
         {
             get { return (string)GetValue(HeaderTextProperty); }
             set { SetValue(HeaderTextProperty, value); }
         }
 
-        public static readonly DependencyProperty HeaderTextProperty =
+		/// <summary>
+		/// Identifies the <see cref="HeaderText"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty HeaderTextProperty =
             DependencyProperty.Register("HeaderText", typeof(string), typeof(SettingsFlyout), new PropertyMetadata(null));
 
 
+		/// <summary>
+		/// Gets or sets the small logo image source.
+		/// </summary>
         public ImageSource SmallLogoImageSource
         {
             get { return (ImageSource)GetValue(SmallLogoImageSourceProperty); }
             set { SetValue(SmallLogoImageSourceProperty, value); }
         }
 
-        public static readonly DependencyProperty SmallLogoImageSourceProperty =
+		/// <summary>
+		/// Identifies the <see cref="SmallLogoImageSource"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty SmallLogoImageSourceProperty =
             DependencyProperty.Register("SmallLogoImageSource", typeof(ImageSource), typeof(SettingsFlyout), null);
 
         /* Issue #81 required these back in to enable overriding to ensure existing
          * apps would be able to retain their existing colors if they were expecting the old defaults
          * */
+		/// <summary>
+		/// Gets or sets the content foreground brush.
+		/// </summary>
         public SolidColorBrush ContentForegroundBrush
         {
             get { return (SolidColorBrush)GetValue(ContentForegroundBrushProperty); }
             set { SetValue(ContentForegroundBrushProperty, value); }
         }
 
-        public static readonly DependencyProperty ContentForegroundBrushProperty =
+		/// <summary>
+		/// Identifies the <see cref="ContentForegroundBrush"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty ContentForegroundBrushProperty =
             DependencyProperty.Register("ContentForegroundBrush", typeof(SolidColorBrush), typeof(SettingsFlyout), null);
 
+		/// <summary>
+		/// Gets or sets the content background brush.
+		/// </summary>
         public SolidColorBrush ContentBackgroundBrush
         {
             get { return (SolidColorBrush)GetValue(ContentBackgroundBrushProperty); }
             set { SetValue(ContentBackgroundBrushProperty, value); }
         }
 
-        public static readonly DependencyProperty ContentBackgroundBrushProperty =
+		/// <summary>
+		/// Identifies the <see cref="ContentBackgroundBrush"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty ContentBackgroundBrushProperty =
             DependencyProperty.Register("ContentBackgroundBrush", typeof(SolidColorBrush), typeof(SettingsFlyout), null);
         
         #endregion Dependency Properties
 
         #region Events
+		/// <summary>
+		/// Occurs when the flyout was closed.
+		/// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly", Justification="Runtime EventHandler")]
         public event EventHandler<object> Closed;
         #endregion
 
         #region Enums
+		/// <summary>
+		/// Flyout width enumeration
+		/// </summary>
         public enum SettingsFlyoutWidth
         {
+			/// <summary>
+			/// A narrow flyout at 346 pixels
+			/// </summary>
             Narrow = 346,
-            Wide = 646
+			/// <summary>
+			/// A wide flyout at 646 pixels
+			/// </summary>
+			Wide = 646
         }
         #endregion Enums
     }
 
+	/// <summary>
+	/// Event argument for the <see cref="E:SetttingsFlyout.BackClicked"/> event.
+	/// </summary>
     public class BackClickedEventArgs : EventArgs
     {
-        public bool Cancel { get; set; }
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="BackClickedEventArgs"/> should be cancelled.
+		/// </summary>
+		public bool Cancel { get; set; }
     }
 }

--- a/src/Callisto/Controls/SettingsManagement/AppSettings.cs
+++ b/src/Callisto/Controls/SettingsManagement/AppSettings.cs
@@ -125,8 +125,9 @@ namespace Callisto.Controls.SettingsManagement
         /// <typeparam name="T">A <see cref="UserControl"/> which represents the content for the settings flyout.</typeparam>
         /// <param name="headerText">The header to be displayed in the Settings charm.</param>
         /// <param name="width">(Optional) The width of the settings flyout. The default is <see cref="SettingsFlyout.SettingsFlyoutWidth.Narrow">SettingsFlyout.SettingsFlyoutWidth.Narrow</see></param>
-        [Obsolete("Use other overloads for Windows 8.1 that don't use FlyoutWidth")]
-        public void AddCommand<T>(string headerText, SettingsFlyout.SettingsFlyoutWidth width = SettingsFlyout.SettingsFlyoutWidth.Narrow) where T : UserControl, new()
+        [Obsolete("Use other overloads for Windows 8.1 that don't use FlyoutWidth")]       
+#pragma warning disable 0618 //Ignore obsolete warning
+		public void AddCommand<T>(string headerText, SettingsFlyout.SettingsFlyoutWidth width = SettingsFlyout.SettingsFlyoutWidth.Narrow) where T : UserControl, new()
         {
             string key = headerText.Trim().Replace(" ", "");
 
@@ -135,6 +136,7 @@ namespace Callisto.Controls.SettingsManagement
                 _commands.Add(key, new SettingsCommandInfo<T>(headerText, width));
             }
         }
+#pragma warning restore 0618
 
         public void AddCommand<T>(string headerText, double width = 500) where T : UserControl, new()
         {

--- a/src/Callisto/Controls/SettingsManagement/SettingsCommandInfo.cs
+++ b/src/Callisto/Controls/SettingsManagement/SettingsCommandInfo.cs
@@ -29,9 +29,11 @@ namespace Callisto.Controls.SettingsManagement
         public SettingsCommandInfo(string headerText, SettingsFlyout.SettingsFlyoutWidth width)
         {
             HeaderText = headerText;
-            Width = width;
-            if (width == SettingsFlyout.SettingsFlyoutWidth.Narrow)
-            {
+#pragma warning disable 0618 //Ignore obsolete warning
+			Width = width;
+			if (width == SettingsFlyout.SettingsFlyoutWidth.Narrow)
+#pragma warning restore 0618
+			{
                 LiteralWidth = 346;
             }
             else

--- a/src/Callisto/Controls/WatermarkTextBox/WatermarkTextBox.cs
+++ b/src/Callisto/Controls/WatermarkTextBox/WatermarkTextBox.cs
@@ -23,6 +23,23 @@ using Windows.UI.Xaml.Input;
 
 namespace Callisto.Controls
 {
+	/// <summary>
+	/// OBSOLETE. WaterMarkTextBox is a derivitave of TextBox that adds only the functionality of providing a default text
+	/// 'hint' in the text input area if no text exists. This is helpful in providing some tip to your users e.g.,
+	/// "Enter your name here..." which will automatically go away when the user starts typing. The Watermark has
+	/// no affect on the Text property or other aspects of the TextBox control.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This control is deprecated in favor of using the  PlaceholderText  property on the  TextBox  controls built in to Windows 8.1
+	/// </para>
+	/// <para>
+	/// WaterMarkTextBox is a derivitave of TextBox that adds only the functionality of providing a default text 'hint' in
+	/// the text input area if no text exists. This is helpful in providing some tip to your users e.g.,
+	/// "Enter your name here..." which will automatically go away when the user starts typing. The Watermark has no affect
+	/// on the Text property or other aspects of the TextBox control.
+	/// </para>
+	/// </remarks>
     [Obsolete("Windows 8.1 now provides this functionality in the XAML framework itself as PlaceholderText on TextBox.")]
     [TemplatePart(Name = WatermarkTextBox.PART_ELEMENT_CONTENT_NAME, Type = typeof(ContentControl))]
     public sealed class WatermarkTextBox : TextBox
@@ -33,6 +50,9 @@ namespace Callisto.Controls
         internal bool HasFocusInternal;
         private ResourceLoader _resources;
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="WatermarkTextBox"/> class.
+		/// </summary>
         public WatermarkTextBox()
         {
             this.DefaultStyleKey = typeof(WatermarkTextBox);
@@ -160,6 +180,12 @@ namespace Callisto.Controls
             }
         }
 
+		/// <summary>
+		/// Invoked whenever application code or internal processes (such as a rebuilding layout pass)
+		/// call ApplyTemplate. In simplest terms, this means the method is called just before a UI
+		/// element displays in your app. Override this method to influence the default post-template 
+		/// logic of a class.
+		/// </summary>
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
@@ -174,13 +200,19 @@ namespace Callisto.Controls
             ChangeVisualState(false);
         }
 
-        public object Watermark
+		/// <summary>
+		/// Gets or sets the watermark.
+		/// </summary>
+		public object Watermark
         {
             get { return (object)GetValue(WatermarkProperty); }
             set { SetValue(WatermarkProperty, value); }
         }
 
-        public static readonly DependencyProperty WatermarkProperty =
+		/// <summary>
+		/// Identifies the <see cref="Watermark"/> dependency property
+		/// </summary>
+		public static readonly DependencyProperty WatermarkProperty =
             DependencyProperty.Register("Watermark", typeof(object), typeof(WatermarkTextBox), new PropertyMetadata(null, OnWatermarkPropertyChanged));
 
         private static void OnWatermarkPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/Callisto/Converters/BooleanToVisibilityConverter.cs
+++ b/src/Callisto/Converters/BooleanToVisibilityConverter.cs
@@ -20,13 +20,39 @@ using Windows.UI.Xaml.Data;
 
 namespace Callisto.Converters
 {
+	/// <summary>
+	/// Converts <see cref="bool"/> <c>true</c> to <see cref="Visibility.Visible" /> and
+	/// <c>false</c> to <see cref="Visibility.Collapsed"/>.
+	/// </summary>
     public class BooleanToVisibilityConverter : IValueConverter
     {
+		/// <summary>
+		/// Modifies the source data before passing it to the target for display in the UI.
+		/// </summary>
+		/// <param name="value">The source data being passed to the target.</param>
+		/// <param name="targetType">The type of the target property. This uses a different
+		/// type depending on whether you're programming with Microsoft .NET or Visual 
+		/// C++ component extensions (C++/CX).</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the target dependency property.
+		/// </returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             return (value is bool && (bool)value) ? Visibility.Visible : Visibility.Collapsed;
         }
 
+		/// <summary>
+		/// Modifies the target data before passing it to the source object. This method is called only in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The target data being passed to the source.</param>
+		/// <param name="targetType">The type of the target property, specified by a helper structure that wraps the type name.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the source object.
+		/// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return value is Visibility && (Visibility)value == Visibility.Visible;

--- a/src/Callisto/Converters/BrushToColorConverter.cs
+++ b/src/Callisto/Converters/BrushToColorConverter.cs
@@ -21,8 +21,22 @@ using Windows.UI.Xaml.Media;
 
 namespace Callisto.Converters
 {
+	/// <summary>
+	/// Gets the color component of a <see cref="SolidColorBrush"/>.
+	/// </summary>
     public class BrushToColorConverter : IValueConverter
     {
+		/// <summary>
+		/// Modifies the source data before passing it to the target for display in the UI.
+		/// </summary>
+		/// <param name="value">The source data being passed to the target.</param>
+		/// <param name="targetType">The type of the target property. This uses a different type depending 
+		/// on whether you're programming with Microsoft .NET or Visual C++ component extensions (C++/CX).</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the target dependency property.
+		/// </returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             SolidColorBrush brush = parameter as SolidColorBrush;
@@ -36,6 +50,16 @@ namespace Callisto.Converters
             }
         }
 
+		/// <summary>
+		/// Modifies the target data before passing it to the source object. This method is called only in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The target data being passed to the source.</param>
+		/// <param name="targetType">The type of the target property, specified by a helper structure that wraps the type name.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the source object.
+		/// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return value;

--- a/src/Callisto/Converters/ColorBrightnessConverter.cs
+++ b/src/Callisto/Converters/ColorBrightnessConverter.cs
@@ -22,8 +22,27 @@ using Windows.UI.Xaml.Media;
 
 namespace Callisto.Converters
 {
+	/// <summary>
+	/// This implementation of an IValueConverter is intended to look at a specific color value
+	/// and apply a brightness value to it based on the ConverterParameter provided. 
+	/// </summary>
+	/// <remarks>
+	/// This is internally used by SettingsFlyout to color the edge 1px Border to be 80% 
+	/// brightness relative to the HeaderBrush color chosen.
+	/// </remarks>
     public class ColorBrightnessConverter : IValueConverter
     {
+		/// <summary>
+		/// Modifies the source data before passing it to the target for display in the UI.
+		/// </summary>
+		/// <param name="value">The source data being passed to the target.</param>
+		/// <param name="targetType">The type of the target property. This uses a different type depending 
+		/// on whether you're programming with Microsoft .NET or Visual C++ component extensions (C++/CX).</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the target dependency property.
+		/// </returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             // parameter should be the brightness factor in double.
@@ -35,6 +54,16 @@ namespace Callisto.Converters
             return new SolidColorBrush(newColor);
         }
 
+		/// <summary>
+		/// Modifies the target data before passing it to the source object. This method is called only in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The target data being passed to the source.</param>
+		/// <param name="targetType">The type of the target property, specified by a helper structure that wraps the type name.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the source object.
+		/// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return value;

--- a/src/Callisto/Converters/ColorContrastConverter.cs
+++ b/src/Callisto/Converters/ColorContrastConverter.cs
@@ -9,8 +9,28 @@ using Windows.UI.Xaml.Media;
 
 namespace Callisto.Converters
 {
+	/// <summary>
+	/// This implementation of an IValueConverter is intended to look at a specific color value
+	/// and determine the contrast based on YIQ and return either <see cref="Windows.UI.Colors.Black"/>
+	/// or <see cref="Windows.UI.Colors.White"/> based on the contrast.
+	/// </summary>
+	/// <remarks>
+	/// This is internally used by SettingsFlyout to determine if the Foreground of the header text 
+	/// should be White/Black based on the HeaderBrush color chosen.
+	/// </remarks>
     public class ColorContrastConverter : IValueConverter
     {
+		/// <summary>
+		/// Modifies the source data before passing it to the target for display in the UI.
+		/// </summary>
+		/// <param name="value">The source data being passed to the target.</param>
+		/// <param name="targetType">The type of the target property. This uses a different type
+		/// depending on whether you're programming with Microsoft .NET or Visual C++ component extensions (C++/CX). See Remarks.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the target dependency property.
+		/// </returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             var brush = (SolidColorBrush)value;
@@ -26,6 +46,16 @@ namespace Callisto.Converters
             return new SolidColorBrush(contrastColor);
         }
 
+		/// <summary>
+		/// Modifies the target data before passing it to the source object. This method is called only in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The target data being passed to the source.</param>
+		/// <param name="targetType">The type of the target property, specified by a helper structure that wraps the type name.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the source object.
+		/// </returns>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return value;

--- a/src/Callisto/Converters/LengthToBooleanConverter.cs
+++ b/src/Callisto/Converters/LengthToBooleanConverter.cs
@@ -19,13 +19,38 @@ using Windows.UI.Xaml.Data;
 
 namespace Callisto.Converters
 {
+	/// <summary>
+	/// Returns <c>true</c> is a string value has a length greater than 0.
+	/// </summary>
     public class StringLengthToBooleanConverter : IValueConverter
     {
+		/// <summary>
+		/// Modifies the source data before passing it to the target for display in the UI.
+		/// </summary>
+		/// <param name="value">The source data being passed to the target.</param>
+		/// <param name="targetType">The type of the target property. This uses a different type
+		/// depending on whether you're programming with Microsoft .NET or Visual C++ component extensions (C++/CX).</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the target dependency property.
+		/// </returns>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             return (((string)value).Length > 0);
         }
 
+		/// <summary>
+		/// Modifies the target data before passing it to the source object. This method is called only in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The target data being passed to the source.</param>
+		/// <param name="targetType">The type of the target property, specified by a helper structure that wraps the type name.</param>
+		/// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+		/// <param name="language">The language of the conversion.</param>
+		/// <returns>
+		/// The value to be passed to the source object.
+		/// </returns>
+		/// <exception cref="System.NotImplementedException"></exception>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException();

--- a/src/Callisto/Extensions/WebViewExtension.cs
+++ b/src/Callisto/Extensions/WebViewExtension.cs
@@ -31,7 +31,7 @@ namespace Callisto
         /// <summary>
         /// Gets the value of the StringSource attached dependency property.
         /// </summary>
-        /// <param name="browser">WebBrowser instance for which to get the value.</param>
+        /// <param name="view">WebBrowser instance for which to get the value.</param>
         /// <returns>Value of the property.</returns>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Method applies only to WebView instances.")]
         public static string GetHtmlSource(WebView view)
@@ -46,7 +46,7 @@ namespace Callisto
         /// <summary>
         /// Sets the value of the StringSource attached dependency property.
         /// </summary>
-        /// <param name="browser">WebBrowser instance for which to set the value.</param>
+        /// <param name="view">WebBrowser instance for which to set the value.</param>
         /// <param name="value">Value to set.</param>
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "Method applies only to WebView instances.")]
         public static void SetHtmlSource(WebView view, string value)

--- a/src/Design/Callisto.Design/DynamicTextBlockMetadata.cs
+++ b/src/Design/Callisto.Design/DynamicTextBlockMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
 		public DynamicTextBlockMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.DynamicTextBlock),
+#pragma warning restore 0618 
 				b =>
 				{
 					b.AddCustomAttributes("LineHeight",

--- a/src/Design/Callisto.Design/FlyoutMetadata.cs
+++ b/src/Design/Callisto.Design/FlyoutMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
 		public FlyoutMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.Flyout),
+#pragma warning restore 0618 
 				b =>
 				{
 					b.AddCustomAttributes("HorizontalOffset",

--- a/src/Design/Callisto.Design/MenuItemMetadata.cs
+++ b/src/Design/Callisto.Design/MenuItemMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
         public MenuItemMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.MenuItem),
+#pragma warning restore 0618 
 				b =>
 				{   
 					b.AddCustomAttributes("Text",

--- a/src/Design/Callisto.Design/MenuItemSeparatorMetadata.cs
+++ b/src/Design/Callisto.Design/MenuItemSeparatorMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
         public MenuItemSeparatorMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.MenuItemSeparator),
+#pragma warning restore 0618 
 				b =>
 				{   
 					b.AddCustomAttributes(new ToolboxCategoryAttribute(ToolboxCategoryPaths.Callisto, false));

--- a/src/Design/Callisto.Design/MenuMetadata.cs
+++ b/src/Design/Callisto.Design/MenuMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
         public MenuMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.Menu),
+#pragma warning restore 0618 
 				b =>
 				{   
 					b.AddCustomAttributes("Items",
@@ -36,9 +38,11 @@ namespace Callisto.Design
 						//The following is necessary because this is a collection of an abstract type, so we help
 						//the designer with populating supported types that can be added to the collection
                         new NewItemTypesAttribute(new System.Type[] {
+#pragma warning disable 0618 //Ignore obsolete warning
                             typeof(Callisto.Controls.MenuItem),
                             typeof(Callisto.Controls.MenuItemSeparator),
                             typeof(Callisto.Controls.ToggleMenuItem)
+#pragma warning restore 0618 
                         }),
 						new AlternateContentPropertyAttribute()
 					);

--- a/src/Design/Callisto.Design/SettingsFlyoutMetadata.cs
+++ b/src/Design/Callisto.Design/SettingsFlyoutMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
 		public SettingsFlyoutMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.SettingsFlyout),
+#pragma warning restore 0618 
 				b =>
 				{
 					b.AddCustomAttributes("HeaderText",

--- a/src/Design/Callisto.Design/ToggleMenuItemMetadata.cs
+++ b/src/Design/Callisto.Design/ToggleMenuItemMetadata.cs
@@ -27,7 +27,9 @@ namespace Callisto.Design
         public ToggleMenuItemMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.ToggleMenuItem),
+#pragma warning restore 0618 
 				b =>
 				{
                     b.AddCustomAttributes("IsChecked",

--- a/src/Design/Callisto.Design/WatermarkTextBoxMetadata.cs
+++ b/src/Design/Callisto.Design/WatermarkTextBoxMetadata.cs
@@ -37,7 +37,9 @@ namespace Callisto.Design
 		public WatermarkTextBoxMetadata()
 			: base()
 		{
+#pragma warning disable 0618 //Ignore obsolete warning
 			AddCallback(typeof(Callisto.Controls.WatermarkTextBox),
+#pragma warning restore 0618 
 				b =>
 				{
                     b.AddCustomAttributes(new FeatureAttribute(typeof(WatermakrTextBoxDefaults)));


### PR DESCRIPTION
@timheuer 
This pull request reduces the number of warnings to 108 (down from 275).
There are no code changes. Two things were changed:
- Added pragma ignores for when obsolete Callisto types were used.
- Added xml doc comments to most classes.

What's left: 
- XML doc comments to mainly OAuthHelper as well as a few other classes. 
- Resolve other obsolete warnings due to changes in WinRT8.1.
